### PR TITLE
Add OpenAPI support and root redirection for API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.threedime</groupId>
   <artifactId>3dime-api</artifactId>
@@ -39,6 +41,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/java/com/threedime/api/ThreeDimeApplication.java
+++ b/src/main/java/com/threedime/api/ThreeDimeApplication.java
@@ -6,6 +6,20 @@ import org.eclipse.microprofile.openapi.annotations.info.Contact;
 import org.eclipse.microprofile.openapi.annotations.info.Info;
 import org.eclipse.microprofile.openapi.annotations.info.License;
 
-@OpenAPIDefinition(info = @Info(title = "3Dime API", version = "1.0.0-SNAPSHOT", description = "The 3Dime API provides GitHub integration functionality", contact = @Contact(name = "3Dime API Support", url = "https://github.com/m-idriss/3dime-api"), license = @License(name = "Apache 2.0", url = "https://www.apache.org/licenses/LICENSE-2.0.html")))
+@OpenAPIDefinition(
+        info = @Info(
+                title = "3Dime API",
+                version = "1.0.0-SNAPSHOT",
+                description = "The 3Dime API provides GitHub integration functionality",
+                contact = @Contact(
+                        name = "3Dime API Support",
+                        url = "https://github.com/m-idriss/3dime-api"
+                ),
+                license = @License(
+                        name = "Apache 2.0",
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.html"
+                )
+        )
+)
 public class ThreeDimeApplication extends Application {
 }

--- a/src/main/java/com/threedime/api/ThreeDimeApplication.java
+++ b/src/main/java/com/threedime/api/ThreeDimeApplication.java
@@ -1,0 +1,11 @@
+package com.threedime.api;
+
+import jakarta.ws.rs.core.Application;
+import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
+import org.eclipse.microprofile.openapi.annotations.info.Contact;
+import org.eclipse.microprofile.openapi.annotations.info.Info;
+import org.eclipse.microprofile.openapi.annotations.info.License;
+
+@OpenAPIDefinition(info = @Info(title = "3Dime API", version = "1.0.0-SNAPSHOT", description = "The 3Dime API provides GitHub integration functionality", contact = @Contact(name = "3Dime API Support", url = "https://github.com/m-idriss/3dime-api"), license = @License(name = "Apache 2.0", url = "https://www.apache.org/licenses/LICENSE-2.0.html")))
+public class ThreeDimeApplication extends Application {
+}

--- a/src/main/java/com/threedime/api/resource/GitHubResource.java
+++ b/src/main/java/com/threedime/api/resource/GitHubResource.java
@@ -7,19 +7,26 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
 @Path("/github")
+@Tag(name = "GitHub", description = "GitHub API operations")
 public class GitHubResource {
-    
+
     private static final Logger LOG = Logger.getLogger(GitHubResource.class);
-    
+
     @Inject
     GitHubService gitHubService;
-    
+
     @GET
     @Path("/user")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Get GitHub user information", description = "Retrieves the authenticated GitHub user information")
+    @APIResponse(responseCode = "200", description = "User information retrieved successfully")
+    @APIResponse(responseCode = "500", description = "Internal server error")
     public GitHubUser getUser() {
         LOG.info("GET /github/user endpoint called");
         return gitHubService.getUserInfo();

--- a/src/main/java/com/threedime/api/resource/GitHubResource.java
+++ b/src/main/java/com/threedime/api/resource/GitHubResource.java
@@ -26,7 +26,7 @@ public class GitHubResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get GitHub user information", description = "Retrieves the authenticated GitHub user information")
     @APIResponse(responseCode = "200", description = "User information retrieved successfully")
-    @APIResponse(responseCode = "500", description = "Internal server error")
+    @APIResponse(responseCode = "502", description = "Failed to fetch user from GitHub API")
     public GitHubUser getUser() {
         LOG.info("GET /github/user endpoint called");
         return gitHubService.getUserInfo();

--- a/src/main/java/com/threedime/api/resource/RootResource.java
+++ b/src/main/java/com/threedime/api/resource/RootResource.java
@@ -1,0 +1,18 @@
+package com.threedime.api.resource;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import java.net.URI;
+
+@Path("/")
+public class RootResource {
+
+    @GET
+    public Response redirectToApiDocs() {
+        return Response
+                .temporaryRedirect(URI.create("/api-docs"))
+                .build();
+    }
+}

--- a/src/main/java/com/threedime/api/resource/RootResource.java
+++ b/src/main/java/com/threedime/api/resource/RootResource.java
@@ -5,8 +5,10 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 
 import java.net.URI;
+import org.eclipse.microprofile.openapi.annotations.Hidden;
 
 @Path("/")
+@Hidden
 public class RootResource {
 
     @GET

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,5 +18,10 @@ quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 # Health Configuration
 quarkus.smallrye-health.root-path=/health
 
+# OpenAPI Configuration
+quarkus.smallrye-openapi.path=/api-schema
+quarkus.swagger-ui.path=/api-docs
+quarkus.swagger-ui.always-include=true
+
 # Application Configuration
 quarkus.application.name=3dime-api


### PR DESCRIPTION
This pull request adds OpenAPI and Swagger UI support to the project, enabling automatic API documentation and improving discoverability for API consumers. It introduces the necessary dependencies, configuration, and annotations to expose and document the API endpoints. Additionally, it includes a root resource to redirect users to the API documentation.

**OpenAPI and Swagger UI Integration:**

* Added the `quarkus-smallrye-openapi` dependency in `pom.xml` to enable OpenAPI support.
* Configured OpenAPI and Swagger UI endpoints in `application.properties` (`/api-schema` for OpenAPI, `/api-docs` for Swagger UI) and ensured Swagger UI is always available.
* Created `ThreeDimeApplication` class with `@OpenAPIDefinition` to provide API metadata such as title, version, description, contact, and license.

**API Documentation Enhancements:**

* Added OpenAPI annotations (`@Tag`, `@Operation`, `@APIResponse`) to `GitHubResource` to document endpoints and responses. [[1]](diffhunk://#diff-1a255dbb372a3d0bf8a0400b17153fb5c88352aba783dde59247c1f73aea0f25R10-R16) [[2]](diffhunk://#diff-1a255dbb372a3d0bf8a0400b17153fb5c88352aba783dde59247c1f73aea0f25R27-R29)

**User Experience Improvements:**

* Introduced `RootResource` to redirect requests from `/` to the API documentation at `/api-docs`.

**Other:**

* Minor formatting improvement in `pom.xml` for better readability.