### PR TITLE
fix: split corrupted config line and add optional GCP credentials via env var

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -169,6 +169,9 @@ quarkus.http.auth.permission.public-ui.policy=permit
 quarkus.http.auth.permission.admin.paths=/users/*,/,/api-docs/*,/api-docs,/api-schema/*,/q/*
 quarkus.http.auth.permission.admin.policy=admin-policy
 
-GOOGLE_CLOUD_PROJECT=quarkus.http.limits.max-body-size=20M
+GOOGLE_CLOUD_PROJECT=image-to-ics
+quarkus.http.limits.max-body-size=20M
 
 quarkus.swagger-ui.theme=flattop
+
+quarkus.google.cloud.service-account-location=${GOOGLE_APPLICATION_CREDENTIALS:}


### PR DESCRIPTION
## Summary
- Fix `GOOGLE_CLOUD_PROJECT` and `quarkus.http.limits.max-body-size` merged on the same line
- Add `quarkus.google.cloud.service-account-location` using optional `${GOOGLE_APPLICATION_CREDENTIALS:}` env var
- Falls back to ADC (workload identity / gcloud) on Mac and Cloud Run when env var is not set

## Test plan
- [ ] Verify API starts on Pi with `GOOGLE_APPLICATION_CREDENTIALS` set in `.env`
- [ ] Verify API starts on Mac using ADC fallback
- [ ] Verify Firestore injection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)