### PR TITLE
security: harden backend configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <!-- Quarkus Platform -->
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.31.3</quarkus.platform.version>
+    <quarkus.platform.version>3.31.4</quarkus.platform.version>
 
     <!-- Maven Plugin Versions -->
     <compiler-plugin.version>3.15.0</compiler-plugin.version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -73,8 +73,8 @@ quarkus.log.console.json.enabled=false
 %prod.quarkus.log.console.json.additional-field.version=1.0.0
 
 # Security Logging for Production Debugging
-quarkus.log.category."io.quarkus.security".level=DEBUG
-%prod.quarkus.log.category."io.quarkus.vertx.http.runtime.security".level=DEBUG
+quarkus.log.category."io.quarkus.security".level=WARN
+%prod.quarkus.log.category."io.quarkus.vertx.http.runtime.security".level=WARN
 
 %test.quarkus.http.test-port=0
 
@@ -121,6 +121,15 @@ quarkus.swagger-ui.urls.admin=${quarkus.smallrye-openapi.admin.path}
 quarkus.swagger-ui.urls.all=${quarkus.smallrye-openapi.all.path}
 quarkus.swagger-ui.urls-primary-name=public
 
+
+# HTTP Security Headers
+quarkus.http.header."X-Content-Type-Options".value=nosniff
+quarkus.http.header."X-Frame-Options".value=DENY
+quarkus.http.header."X-XSS-Protection".value=1; mode=block
+quarkus.http.header."Referrer-Policy".value=strict-origin-when-cross-origin
+quarkus.http.header."Permissions-Policy".value=geolocation=(), microphone=(), camera=()
+%prod.quarkus.http.header."Strict-Transport-Security".value=max-age=31536000; includeSubDomains; preload
+
 # Health Configuration
 quarkus.smallrye-health.root-path=/health
 
@@ -129,7 +138,7 @@ quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=https://www.3dime.com,https://3dime.com,https://www.photocalia.com,https://photocalia.com
 quarkus.http.cors.methods=GET,PUT,POST,DELETE,PATCH,OPTIONS
 quarkus.http.cors.headers=accept,authorization,content-type,x-requested-with
-quarkus.http.cors.exposed-headers=*
+quarkus.http.cors.exposed-headers=Content-Disposition,Content-Type
 quarkus.http.cors.access-control-max-age=24H
 %dev.quarkus.http.cors.origins=*
 
@@ -151,7 +160,7 @@ quarkus.http.auth.form.cookie-name=quarkus-credential
 
 quarkus.security.users.embedded.enabled=true
 quarkus.security.users.embedded.plain-text=true
-quarkus.security.users.embedded.users.admin=${ADMIN_PASSWORD:password}
+quarkus.security.users.embedded.users.admin=${ADMIN_PASSWORD}
 quarkus.security.users.embedded.roles.admin=admin
 
 # Auth Policy


### PR DESCRIPTION
## Summary
- Upgrade Quarkus BOM `3.31.3` → `3.31.4` (fixes Netty, Vert.x and Quarkus transitive CVEs)
- Add HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy`, `HSTS` in prod only)
- Fix CORS `exposed-headers=*` wildcard → explicit `Content-Disposition,Content-Type`
- Remove insecure default fallback `password` for `ADMIN_PASSWORD`
- Downgrade security log level `DEBUG` → `WARN` to avoid info leakage in logs

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)