### PR TITLE
Feat/claude ai provider

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/ClaudeClient.java
+++ b/src/main/java/com/dime/api/feature/converter/ClaudeClient.java
@@ -1,0 +1,20 @@
+package com.dime.api.feature.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/v1")
+@RegisterRestClient(configKey = "claude-api")
+public interface ClaudeClient {
+
+    @POST
+    @Path("/messages")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    JsonNode createMessage(
+            @HeaderParam("x-api-key") String apiKey,
+            @HeaderParam("anthropic-version") String version,
+            Object body);
+}

--- a/src/main/java/com/dime/api/feature/converter/ClaudeService.java
+++ b/src/main/java/com/dime/api/feature/converter/ClaudeService.java
@@ -1,0 +1,128 @@
+package com.dime.api.feature.converter;
+
+import com.dime.api.feature.shared.exception.ExternalServiceException;
+import com.dime.api.feature.shared.exception.ProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@ApplicationScoped
+public class ClaudeService {
+
+    private static final Pattern BASE64_PATTERN = Pattern.compile("^data:(.+?);base64,(.+)$");
+    private static final String ANTHROPIC_VERSION = "2023-06-01";
+
+    @Inject
+    @RestClient
+    ClaudeClient claudeClient;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @ConfigProperty(name = "claude.model", defaultValue = "claude-3-5-sonnet-20241022")
+    String modelName;
+
+    @ConfigProperty(name = "gemini.base-message")
+    String baseMessageTemplate;
+
+    @ConfigProperty(name = "gemini.system-prompt")
+    String systemPrompt;
+
+    @ConfigProperty(name = "claude.api.key")
+    Optional<String> apiKey;
+
+    public String generateIcs(ConverterRequest request) {
+        if (apiKey.isEmpty() || apiKey.get().trim().isEmpty()) {
+            throw new ExternalServiceException("Claude", "Missing Claude API key (CLAUDE_API_KEY)");
+        }
+
+        String today = request.currentDate != null ? request.currentDate : java.time.LocalDate.now().toString();
+        String tz = request.timeZone != null ? request.timeZone : "UTC";
+        String baseMessage = baseMessageTemplate.replace("{today}", today).replace("{tz}", tz);
+
+        ObjectNode requestBody = objectMapper.createObjectNode();
+        requestBody.put("model", modelName);
+        requestBody.put("max_tokens", 8192);
+        requestBody.put("system", systemPrompt);
+
+        ArrayNode messages = requestBody.putArray("messages");
+        ObjectNode userMessage = messages.addObject();
+        userMessage.put("role", "user");
+        ArrayNode content = userMessage.putArray("content");
+
+        // Add images
+        if (request.files != null) {
+            for (ConverterRequest.ImageFile file : request.files) {
+                String dataUrl = file.dataUrl != null ? file.dataUrl : file.url;
+                if (dataUrl != null) {
+                    Matcher matcher = BASE64_PATTERN.matcher(dataUrl);
+                    if (matcher.find()) {
+                        String mimeType = matcher.group(1);
+                        String data = matcher.group(2);
+
+                        ObjectNode imagePart = content.addObject();
+                        imagePart.put("type", "image");
+                        ObjectNode source = imagePart.putObject("source");
+                        source.put("type", "base64");
+                        source.put("media_type", mimeType);
+                        source.put("data", data);
+                    } else if (file.url != null) {
+                        log.warn("URL-based image files are not yet supported. Skipping: {}", file.url);
+                    }
+                }
+            }
+        }
+
+        // Add text prompt
+        content.addObject().put("type", "text").put("text", baseMessage);
+
+        log.info("Calling Claude API with model {}", modelName);
+
+        JsonNode response;
+        try {
+            response = claudeClient.createMessage(apiKey.get(), ANTHROPIC_VERSION, requestBody);
+        } catch (Exception e) {
+            log.error("Failed to call Claude API", e);
+            throw new ExternalServiceException("Claude",
+                    "Failed to generate content using Claude API: " + e.getMessage(), e);
+        }
+
+        if (response.has("error")) {
+            String error = response.get("error").toString();
+            log.error("Claude API returned error: {}", error);
+            throw new ExternalServiceException("Claude", "Claude API error: " + error);
+        }
+
+        String stopReason = response.has("stop_reason") ? response.get("stop_reason").asText() : "";
+        if (!"end_turn".equals(stopReason)) {
+            log.warn("Claude response was blocked or incomplete: {}", stopReason);
+            throw new ProcessingException("Content generation was blocked or incomplete. " +
+                    "Please try with different images. Reason: " + stopReason);
+        }
+
+        if (response.has("content") && response.get("content").size() > 0) {
+            String text = response.get("content").get(0).get("text").asText();
+            return cleanIcs(text);
+        }
+
+        log.error("Claude response did not contain expected content: {}", response.toString());
+        throw new ProcessingException("Claude API returned unexpected response format");
+    }
+
+    String cleanIcs(String text) {
+        if (text == null)
+            return null;
+        return text.replaceAll("```(?:ics)?\\s*[\\r\\n]|```", "").trim();
+    }
+}

--- a/src/main/java/com/dime/api/feature/converter/ConverterResource.java
+++ b/src/main/java/com/dime/api/feature/converter/ConverterResource.java
@@ -19,6 +19,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -35,7 +37,13 @@ public class ConverterResource {
     GeminiService geminiService;
 
     @Inject
+    ClaudeService claudeService;
+
+    @Inject
     TrackingService trackingService;
+
+    @ConfigProperty(name = "ai.provider", defaultValue = "claude")
+    String aiProvider;
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -76,8 +84,10 @@ public class ConverterResource {
         }
 
         try {
-            // Call Gemini
-            String icsContent = geminiService.generateIcs(request);
+            // Call AI provider
+            String icsContent = "gemini".equalsIgnoreCase(aiProvider)
+                    ? geminiService.generateIcs(request)
+                    : claudeService.generateIcs(request);
 
             if (icsContent == null || icsContent.isEmpty() || icsContent.equalsIgnoreCase("null")) {
                 trackingService.logConversionError(userId, fileCount, "No events found in images",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,6 +39,14 @@ gemini.api.key=${GEMINI_API_KEY:}
 quarkus.rest-client."gemini-api".url=https://generativelanguage.googleapis.com
 quarkus.rest-client."gemini-api".scope=jakarta.inject.Singleton
 
+# Claude Configuration
+claude.model=${CLAUDE_MODEL:claude-3-5-sonnet-20241022}
+claude.api.key=${CLAUDE_API_KEY:}
+ai.provider=${AI_PROVIDER:claude}
+
+quarkus.rest-client."claude-api".url=https://api.anthropic.com
+quarkus.rest-client."claude-api".scope=jakarta.inject.Singleton
+
 # Error Handling Configuration
 quarkus.log.category."com.dime.api.feature.shared.exception".level=DEBUG
 %dev.quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,7 +42,7 @@ quarkus.rest-client."gemini-api".scope=jakarta.inject.Singleton
 # Claude Configuration
 claude.model=${CLAUDE_MODEL:claude-sonnet-4-5}
 claude.api.key=${CLAUDE_API_KEY:}
-ai.provider=${AI_PROVIDER:claude}
+ai.provider=${AI_PROVIDER:gemini}
 
 quarkus.rest-client."claude-api".url=https://api.anthropic.com
 quarkus.rest-client."claude-api".scope=jakarta.inject.Singleton

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,7 +40,7 @@ quarkus.rest-client."gemini-api".url=https://generativelanguage.googleapis.com
 quarkus.rest-client."gemini-api".scope=jakarta.inject.Singleton
 
 # Claude Configuration
-claude.model=${CLAUDE_MODEL:claude-3-5-sonnet-20241022}
+claude.model=${CLAUDE_MODEL:claude-sonnet-4-5}
 claude.api.key=${CLAUDE_API_KEY:}
 ai.provider=${AI_PROVIDER:claude}
 

--- a/src/test/java/com/dime/api/feature/converter/ClaudeServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/ClaudeServiceTest.java
@@ -1,0 +1,210 @@
+package com.dime.api.feature.converter;
+
+import com.dime.api.feature.shared.exception.ExternalServiceException;
+import com.dime.api.feature.shared.exception.ProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class ClaudeServiceTest {
+
+    private ClaudeService service;
+    private ClaudeClient mockClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setup() {
+        service = new ClaudeService();
+        mockClient = mock(ClaudeClient.class);
+        service.claudeClient = mockClient;
+        service.objectMapper = objectMapper;
+        service.apiKey = Optional.of("test-api-key");
+        service.modelName = "claude-3-5-sonnet-20241022";
+        service.baseMessageTemplate = "Convert these images to ICS. Today is {today}, timezone is {tz}.";
+        service.systemPrompt = "You are a calendar assistant.";
+    }
+
+    // --- cleanIcs ---
+
+    @Test
+    public void testCleanIcs_removesMarkdownIcsBlock() {
+        String dirty = "```ics\nBEGIN:VCALENDAR\nSUMMARY:Test\nEND:VCALENDAR\n```";
+        String cleaned = service.cleanIcs(dirty);
+        assertNotNull(cleaned);
+        assertFalse(cleaned.contains("```"));
+        assertTrue(cleaned.contains("BEGIN:VCALENDAR"));
+    }
+
+    @Test
+    public void testCleanIcs_removesGenericCodeBlock() {
+        String dirty = "```\nBEGIN:VCALENDAR\nEND:VCALENDAR\n```";
+        String cleaned = service.cleanIcs(dirty);
+        assertFalse(cleaned.contains("```"));
+        assertTrue(cleaned.contains("BEGIN:VCALENDAR"));
+    }
+
+    @Test
+    public void testCleanIcs_alreadyClean() {
+        String clean = "BEGIN:VCALENDAR\nSUMMARY:Test\nEND:VCALENDAR";
+        assertEquals(clean, service.cleanIcs(clean));
+    }
+
+    @Test
+    public void testCleanIcs_null() {
+        assertNull(service.cleanIcs(null));
+    }
+
+    // --- generateIcs: API key validation ---
+
+    @Test
+    public void testGenerateIcs_missingApiKey_throwsExternalServiceException() {
+        service.apiKey = Optional.empty();
+        assertThrows(ExternalServiceException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+    }
+
+    @Test
+    public void testGenerateIcs_blankApiKey_throwsExternalServiceException() {
+        service.apiKey = Optional.of("   ");
+        assertThrows(ExternalServiceException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+    }
+
+    // --- generateIcs: successful response ---
+
+    @Test
+    public void testGenerateIcs_validResponse_returnsIcsContent() {
+        String icsContent = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR";
+        when(mockClient.createMessage(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+        ConverterRequest request = buildRequestWithBase64Image();
+        request.currentDate = "2026-02-22";
+        request.timeZone = "UTC";
+
+        String result = service.generateIcs(request);
+
+        assertNotNull(result);
+        assertTrue(result.contains("BEGIN:VCALENDAR"));
+    }
+
+    @Test
+    public void testGenerateIcs_stripsMarkdownFromResponse() {
+        String icsContent = "```ics\nBEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR\n```";
+        when(mockClient.createMessage(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+        String result = service.generateIcs(buildRequestWithBase64Image());
+
+        assertFalse(result.contains("```"));
+        assertTrue(result.startsWith("BEGIN:VCALENDAR"));
+    }
+
+    @Test
+    public void testGenerateIcs_nullCurrentDateAndTimezone_usesDefaults() {
+        String icsContent = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR";
+        when(mockClient.createMessage(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+        ConverterRequest request = buildRequestWithBase64Image();
+        // currentDate and timeZone intentionally left null
+
+        assertDoesNotThrow(() -> service.generateIcs(request));
+    }
+
+    // --- generateIcs: error cases ---
+
+    @Test
+    public void testGenerateIcs_apiErrorField_throwsExternalServiceException() {
+        ObjectNode errorResponse = objectMapper.createObjectNode();
+        errorResponse.putObject("error")
+                .put("type", "authentication_error")
+                .put("message", "Invalid API key");
+        when(mockClient.createMessage(any(), any(), any())).thenReturn(errorResponse);
+
+        assertThrows(ExternalServiceException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+    }
+
+    @Test
+    public void testGenerateIcs_contentBlocked_throwsProcessingException() {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("stop_reason", "max_tokens");
+        response.putArray("content").addObject().put("type", "text").put("text", "Partial");
+        when(mockClient.createMessage(any(), any(), any())).thenReturn(response);
+
+        assertThrows(ProcessingException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+    }
+
+    @Test
+    public void testGenerateIcs_clientThrows_throwsExternalServiceException() {
+        when(mockClient.createMessage(any(), any(), any()))
+                .thenThrow(new RuntimeException("Connection refused"));
+
+        assertThrows(ExternalServiceException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+    }
+
+    @Test
+    public void testGenerateIcs_emptyContent_throwsProcessingException() {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("stop_reason", "end_turn");
+        response.putArray("content"); // empty content array
+        when(mockClient.createMessage(any(), any(), any())).thenReturn(response);
+
+        assertThrows(ProcessingException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+    }
+
+    // --- generateIcs: image handling ---
+
+    @Test
+    public void testGenerateIcs_urlBasedImage_skippedWithWarning() {
+        String icsContent = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR";
+        when(mockClient.createMessage(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+        ConverterRequest request = new ConverterRequest();
+        ConverterRequest.ImageFile file = new ConverterRequest.ImageFile();
+        file.url = "https://example.com/image.png"; // URL-based images are skipped
+        request.files = List.of(file);
+
+        // Should not throw — URL images are skipped with a log warning
+        assertDoesNotThrow(() -> service.generateIcs(request));
+    }
+
+    @Test
+    public void testGenerateIcs_multipleMixedFiles_processesBase64Only() {
+        String icsContent = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR";
+        when(mockClient.createMessage(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+        ConverterRequest request = new ConverterRequest();
+        ConverterRequest.ImageFile urlFile = new ConverterRequest.ImageFile();
+        urlFile.url = "https://example.com/image.png";
+        ConverterRequest.ImageFile base64File = new ConverterRequest.ImageFile();
+        base64File.dataUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+        request.files = List.of(urlFile, base64File);
+
+        String result = service.generateIcs(request);
+        assertNotNull(result);
+        verify(mockClient, times(1)).createMessage(any(), any(), any());
+    }
+
+    // --- helpers ---
+
+    private ConverterRequest buildRequestWithBase64Image() {
+        ConverterRequest request = new ConverterRequest();
+        ConverterRequest.ImageFile file = new ConverterRequest.ImageFile();
+        file.dataUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+        request.files = List.of(file);
+        return request;
+    }
+
+    private ObjectNode buildSuccessResponse(String icsContent) {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("stop_reason", "end_turn");
+        response.putArray("content").addObject()
+                .put("type", "text")
+                .put("text", icsContent);
+        return response;
+    }
+}


### PR DESCRIPTION
This pull request introduces support for the Claude AI provider as an alternative to Gemini for calendar event extraction from images. The main changes include implementing a new Claude client and service, updating the application configuration to allow switching between providers, and modifying the conversion logic to select the AI provider dynamically. Comprehensive unit tests for the Claude service have also been added.

**Claude AI Integration:**

* Added `ClaudeClient` interface for REST communication with the Claude API. (`src/main/java/com/dime/api/feature/converter/ClaudeClient.java`)
* Implemented `ClaudeService` for handling requests, image processing, error handling, and ICS content cleaning using Claude. (`src/main/java/com/dime/api/feature/converter/ClaudeService.java`)
* Added unit tests for `ClaudeService`, covering successful responses, error cases, image handling, and ICS cleaning. (`src/test/java/com/dime/api/feature/converter/ClaudeServiceTest.java`)

**Dynamic AI Provider Selection:**

* Updated `ConverterResource` to inject `ClaudeService` and select the AI provider based on the `ai.provider` configuration property. (`src/main/java/com/dime/api/feature/converter/ConverterResource.java`) [[1]](diffhunk://#diff-818ff8ed2e52c0a0a89c4b0f76538ded930974985153f77426b443dbced84ddcR22-R23) [[2]](diffhunk://#diff-818ff8ed2e52c0a0a89c4b0f76538ded930974985153f77426b443dbced84ddcR39-R47) [[3]](diffhunk://#diff-818ff8ed2e52c0a0a89c4b0f76538ded930974985153f77426b443dbced84ddcL79-R90)

**Configuration Updates:**

* Added Claude-related properties and AI provider selection to `application.properties`, including model name, API key, and REST client configuration. (`src/main/resources/application.properties`)