### PR TITLE
feat: add fault tolerance timeouts and fix swagger validator badge

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/ClaudeService.java
+++ b/src/main/java/com/dime/api/feature/converter/ClaudeService.java
@@ -10,8 +10,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -42,6 +44,7 @@ public class ClaudeService {
     @ConfigProperty(name = "claude.api.key")
     Optional<String> apiKey;
 
+    @Timeout(value = 60, unit = ChronoUnit.SECONDS)
     public String generateIcs(ConverterRequest request) {
         if (apiKey.isEmpty() || apiKey.get().trim().isEmpty()) {
             throw new ExternalServiceException("Claude", "Missing Claude API key (CLAUDE_API_KEY)");

--- a/src/main/java/com/dime/api/feature/converter/GeminiService.java
+++ b/src/main/java/com/dime/api/feature/converter/GeminiService.java
@@ -11,11 +11,13 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -48,6 +50,7 @@ public class GeminiService {
     @ConfigProperty(name = "gemini.api.key")
     Optional<String> apiKeyJson;
 
+    @Timeout(value = 60, unit = ChronoUnit.SECONDS)
     public String generateIcs(ConverterRequest request) throws IOException {
         String token;
         try {

--- a/src/main/java/com/dime/api/feature/github/GitHubService.java
+++ b/src/main/java/com/dime/api/feature/github/GitHubService.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,6 +38,7 @@ public class GitHubService {
   ObjectMapper objectMapper;
 
   @CacheResult(cacheName = "github-user-cache")
+  @Timeout(value = 10, unit = ChronoUnit.SECONDS)
   public GitHubUser getUserInfo() {
     log.info("Fetching GitHub user info for: {}", username);
 
@@ -56,6 +58,7 @@ public class GitHubService {
   }
 
   @CacheResult(cacheName = "github-social-cache")
+  @Timeout(value = 10, unit = ChronoUnit.SECONDS)
   public JsonNode getSocialAccounts() {
     try {
       return gitHubClient.getSocialAccounts(getAuthHeader().orElse(null), username);
@@ -76,6 +79,7 @@ public class GitHubService {
   }
 
   @CacheResult(cacheName = "github-commits-cache")
+  @Timeout(value = 10, unit = ChronoUnit.SECONDS)
   public List<Map<String, Object>> getCommits(int months) {
     // Validate months parameter
     if (months < 1 || months > 60) {

--- a/src/main/java/com/dime/api/feature/notion/NotionService.java
+++ b/src/main/java/com/dime/api/feature/notion/NotionService.java
@@ -9,9 +9,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +40,7 @@ public class NotionService {
     ObjectMapper objectMapper;
 
     @CacheResult(cacheName = "notion-cms-cache")
+    @Timeout(value = 10, unit = ChronoUnit.SECONDS)
     public Map<String, List<CmsItem>> getCmsContent() {
         if (databaseId == null || databaseId.trim().isEmpty()) {
             log.warn("Notion CMS database ID not configured (notion.cms.database-id). Returning empty content.");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,9 +18,13 @@ quarkus.http.auth.session.encryption-key=${AUTH_SESSION_ENCRYPTION_KEY:}
 # REST Client Configuration
 quarkus.rest-client."com.dime.api.feature.github.GitHubClient".url=${github.api.url}
 quarkus.rest-client."com.dime.api.feature.github.GitHubClient".scope=jakarta.inject.Singleton
+quarkus.rest-client."com.dime.api.feature.github.GitHubClient".connect-timeout=5000
+quarkus.rest-client."com.dime.api.feature.github.GitHubClient".read-timeout=12000
 
 quarkus.rest-client."notion-api".url=https://api.notion.com
 quarkus.rest-client."notion-api".scope=jakarta.inject.Singleton
+quarkus.rest-client."notion-api".connect-timeout=5000
+quarkus.rest-client."notion-api".read-timeout=12000
 
 # Notion Configuration
 notion.token=${NOTION_TOKEN}
@@ -38,6 +42,8 @@ gemini.api.key=${GEMINI_API_KEY:}
 
 quarkus.rest-client."gemini-api".url=https://generativelanguage.googleapis.com
 quarkus.rest-client."gemini-api".scope=jakarta.inject.Singleton
+quarkus.rest-client."gemini-api".connect-timeout=5000
+quarkus.rest-client."gemini-api".read-timeout=65000
 
 # Claude Configuration
 claude.model=${CLAUDE_MODEL:claude-sonnet-4-5}
@@ -46,6 +52,8 @@ ai.provider=${AI_PROVIDER:gemini}
 
 quarkus.rest-client."claude-api".url=https://api.anthropic.com
 quarkus.rest-client."claude-api".scope=jakarta.inject.Singleton
+quarkus.rest-client."claude-api".connect-timeout=5000
+quarkus.rest-client."claude-api".read-timeout=65000
 
 # Error Handling Configuration
 quarkus.log.category."com.dime.api.feature.shared.exception".level=DEBUG
@@ -190,5 +198,6 @@ GOOGLE_CLOUD_PROJECT=image-to-ics
 quarkus.http.limits.max-body-size=20M
 
 quarkus.swagger-ui.theme=flattop
+quarkus.swagger-ui.validator-url=none
 
 quarkus.google.cloud.service-account-location=${GOOGLE_APPLICATION_CREDENTIALS:}


### PR DESCRIPTION
- Add @Timeout(60s) to GeminiService and ClaudeService to prevent hung AI requests
- Add @Timeout(10s) to GitHubService (all 3 methods) and NotionService
- Handle MicroProfile TimeoutException in GlobalExceptionMapper → 504 response
- Add REST client connect/read timeouts in application.properties (belt-and-suspenders)
- Disable Swagger UI validator badge (quarkus.swagger-ui.validator-url=none)