### PR TITLE
feat: low priority improvements — DRY refactor, test coverage, dead c…

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/ClaudeService.java
+++ b/src/main/java/com/dime/api/feature/converter/ClaudeService.java
@@ -137,8 +137,6 @@ public class ClaudeService {
     }
 
     String cleanIcs(String text) {
-        if (text == null)
-            return null;
-        return text.replaceAll("```(?:ics)?\\s*[\\r\\n]|```", "").trim();
+        return IcsUtils.cleanIcs(text);
     }
 }

--- a/src/main/java/com/dime/api/feature/converter/ConverterResponse.java
+++ b/src/main/java/com/dime/api/feature/converter/ConverterResponse.java
@@ -28,21 +28,4 @@ public class ConverterResponse {
         this.success = success;
         this.icsContent = icsContent;
     }
-
-    public static ConverterResponse error(String error, String message) {
-        ConverterResponse response = new ConverterResponse();
-        response.success = false;
-        response.error = error;
-        response.message = message;
-        return response;
-    }
-
-    public static ConverterResponse error(String error, String message, Object details) {
-        ConverterResponse response = new ConverterResponse();
-        response.success = false;
-        response.error = error;
-        response.message = message;
-        response.details = details;
-        return response;
-    }
 }

--- a/src/main/java/com/dime/api/feature/converter/GeminiService.java
+++ b/src/main/java/com/dime/api/feature/converter/GeminiService.java
@@ -164,9 +164,6 @@ public class GeminiService {
     }
 
     String cleanIcs(String text) {
-        if (text == null)
-            return null;
-        String cleaned = text.replaceAll("```(?:ics)?\\s*[\\r\\n]|```", "").trim();
-        return cleaned;
+        return IcsUtils.cleanIcs(text);
     }
 }

--- a/src/main/java/com/dime/api/feature/converter/IcsUtils.java
+++ b/src/main/java/com/dime/api/feature/converter/IcsUtils.java
@@ -1,0 +1,22 @@
+package com.dime.api.feature.converter;
+
+/**
+ * Shared utility for ICS content post-processing.
+ */
+final class IcsUtils {
+
+    private IcsUtils() {
+    }
+
+    /**
+     * Strips markdown code block fences (```ics or ```) from AI-generated ICS text.
+     *
+     * @param text raw text returned by an AI model
+     * @return cleaned ICS string, or {@code null} if input is {@code null}
+     */
+    static String cleanIcs(String text) {
+        if (text == null)
+            return null;
+        return text.replaceAll("```(?:ics)?\\s*[\\r\\n]|```", "").trim();
+    }
+}

--- a/src/main/java/com/dime/api/feature/notion/NotionService.java
+++ b/src/main/java/com/dime/api/feature/notion/NotionService.java
@@ -1,5 +1,6 @@
 package com.dime.api.feature.notion;
 
+import com.dime.api.feature.shared.BearerTokenUtil;
 import com.dime.api.feature.shared.exception.ExternalServiceException;
 import io.quarkus.cache.CacheResult;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -64,7 +65,7 @@ public class NotionService {
             sort.put("property", "Rank");
             sort.put("direction", "ascending");
 
-            String authToken = bearerToken(token);
+            String authToken = BearerTokenUtil.ensureBearer(token);
             JsonNode response = notionClient.queryDatabase(authToken, version, databaseId, query);
 
             Map<String, List<CmsItem>> groupedContent = new HashMap<>();
@@ -136,12 +137,6 @@ public class NotionService {
             return prop.get("select").get("name").asText(defaultValue);
         }
         return defaultValue;
-    }
-
-    private String bearerToken(String raw) {
-        if (raw == null)
-            return null;
-        return raw.startsWith("Bearer ") ? raw : "Bearer " + raw;
     }
 
     public record CmsItem(String name, String url, String description, long rank, String category) {

--- a/src/main/java/com/dime/api/feature/shared/BearerTokenUtil.java
+++ b/src/main/java/com/dime/api/feature/shared/BearerTokenUtil.java
@@ -1,0 +1,22 @@
+package com.dime.api.feature.shared;
+
+/**
+ * Shared utility for ensuring HTTP Authorization header values include the "Bearer " prefix.
+ */
+public final class BearerTokenUtil {
+
+    private BearerTokenUtil() {
+    }
+
+    /**
+     * Returns the token with a "Bearer " prefix, adding it only if not already present.
+     *
+     * @param raw raw token string (may already start with "Bearer ")
+     * @return properly prefixed bearer token, or {@code null} if input is {@code null}
+     */
+    public static String ensureBearer(String raw) {
+        if (raw == null)
+            return null;
+        return raw.startsWith("Bearer ") ? raw : "Bearer " + raw;
+    }
+}

--- a/src/test/java/com/dime/api/feature/converter/GeminiServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/GeminiServiceTest.java
@@ -1,15 +1,21 @@
 package com.dime.api.feature.converter;
 
+import com.dime.api.feature.shared.exception.ExternalServiceException;
+import com.dime.api.feature.shared.exception.ProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @QuarkusTest
@@ -54,6 +60,188 @@ public class GeminiServiceTest {
         } catch (IOException e) {
             // Acceptable if environment does not provide application default credentials
             assertTrue(e.getMessage().contains("credentials"));
+        }
+    }
+
+    // --- Behavior tests (plain unit tests, no Quarkus context needed) ---
+
+    @Nested
+    class BehaviorTest {
+
+        private GeminiService service;
+        private GeminiClient mockClient;
+        private final ObjectMapper mapper = new ObjectMapper();
+
+        @BeforeEach
+        void setup() throws IOException {
+            service = spy(new GeminiService());
+            mockClient = mock(GeminiClient.class);
+            service.geminiClient = mockClient;
+            service.objectMapper = mapper;
+            service.modelName = "gemini-test-model";
+            service.baseMessageTemplate = "Convert images. Today is {today}, tz={tz}.";
+            service.systemPrompt = "You are a calendar assistant.";
+            service.apiKeyJson = Optional.of("{}");
+            doReturn("fake-token").when(service).getAccessToken();
+        }
+
+        // --- cleanIcs ---
+
+        @Test
+        void testCleanIcs_removesMarkdownIcsBlock() {
+            String dirty = "```ics\nBEGIN:VCALENDAR\nSUMMARY:Test\nEND:VCALENDAR\n```";
+            String cleaned = service.cleanIcs(dirty);
+            assertNotNull(cleaned);
+            assertFalse(cleaned.contains("```"));
+            assertTrue(cleaned.contains("BEGIN:VCALENDAR"));
+        }
+
+        @Test
+        void testCleanIcs_removesGenericCodeBlock() {
+            String dirty = "```\nBEGIN:VCALENDAR\nEND:VCALENDAR\n```";
+            String cleaned = service.cleanIcs(dirty);
+            assertFalse(cleaned.contains("```"));
+            assertTrue(cleaned.contains("BEGIN:VCALENDAR"));
+        }
+
+        @Test
+        void testCleanIcs_alreadyClean() {
+            String clean = "BEGIN:VCALENDAR\nSUMMARY:Test\nEND:VCALENDAR";
+            assertEquals(clean, service.cleanIcs(clean));
+        }
+
+        @Test
+        void testCleanIcs_null() {
+            assertNull(service.cleanIcs(null));
+        }
+
+        // --- generateIcs: successful responses ---
+
+        @Test
+        void testGenerateIcs_validResponse_returnsIcsContent() throws IOException {
+            String icsContent = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR";
+            when(mockClient.generateContent(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+            ConverterRequest request = buildRequestWithBase64Image();
+            request.currentDate = "2026-02-22";
+            request.timeZone = "UTC";
+
+            String result = service.generateIcs(request);
+
+            assertNotNull(result);
+            assertTrue(result.contains("BEGIN:VCALENDAR"));
+        }
+
+        @Test
+        void testGenerateIcs_stripsMarkdownFromResponse() throws IOException {
+            String icsContent = "```ics\nBEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR\n```";
+            when(mockClient.generateContent(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+            String result = service.generateIcs(buildRequestWithBase64Image());
+
+            assertFalse(result.contains("```"));
+            assertTrue(result.startsWith("BEGIN:VCALENDAR"));
+        }
+
+        @Test
+        void testGenerateIcs_nullCurrentDateAndTimezone_usesDefaults() throws IOException {
+            String icsContent = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR";
+            when(mockClient.generateContent(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+            ConverterRequest request = buildRequestWithBase64Image();
+            // currentDate and timeZone intentionally left null
+
+            assertDoesNotThrow(() -> service.generateIcs(request));
+        }
+
+        // --- generateIcs: error cases ---
+
+        @Test
+        void testGenerateIcs_finishReasonNotStop_throwsProcessingException() {
+            ObjectNode response = mapper.createObjectNode();
+            ObjectNode candidate = response.putArray("candidates").addObject();
+            candidate.put("finishReason", "SAFETY");
+            candidate.putObject("content").putArray("parts").addObject().put("text", "Partial");
+            when(mockClient.generateContent(any(), any(), any())).thenReturn(response);
+
+            assertThrows(ProcessingException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+        }
+
+        @Test
+        void testGenerateIcs_errorField_throwsExternalServiceException() {
+            ObjectNode errorResponse = mapper.createObjectNode();
+            errorResponse.putObject("error").put("message", "API quota exceeded");
+            when(mockClient.generateContent(any(), any(), any())).thenReturn(errorResponse);
+
+            assertThrows(ExternalServiceException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+        }
+
+        @Test
+        void testGenerateIcs_clientThrows_throwsExternalServiceException() {
+            when(mockClient.generateContent(any(), any(), any()))
+                    .thenThrow(new RuntimeException("Connection refused"));
+
+            assertThrows(ExternalServiceException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+        }
+
+        @Test
+        void testGenerateIcs_noCandidates_throwsProcessingException() {
+            ObjectNode response = mapper.createObjectNode();
+            response.putArray("candidates"); // empty array
+            when(mockClient.generateContent(any(), any(), any())).thenReturn(response);
+
+            assertThrows(ProcessingException.class, () -> service.generateIcs(buildRequestWithBase64Image()));
+        }
+
+        // --- generateIcs: image handling ---
+
+        @Test
+        void testGenerateIcs_urlBasedImage_skippedWithWarning() throws IOException {
+            String icsContent = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR";
+            when(mockClient.generateContent(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+            ConverterRequest request = new ConverterRequest();
+            ConverterRequest.ImageFile file = new ConverterRequest.ImageFile();
+            file.url = "https://example.com/image.png"; // URL-based images are skipped
+            request.files = List.of(file);
+
+            // Should not throw — URL images are skipped with a log warning
+            assertDoesNotThrow(() -> service.generateIcs(request));
+        }
+
+        @Test
+        void testGenerateIcs_multipleMixedFiles_processesBase64Only() throws IOException {
+            String icsContent = "BEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:Test\nEND:VEVENT\nEND:VCALENDAR";
+            when(mockClient.generateContent(any(), any(), any())).thenReturn(buildSuccessResponse(icsContent));
+
+            ConverterRequest request = new ConverterRequest();
+            ConverterRequest.ImageFile urlFile = new ConverterRequest.ImageFile();
+            urlFile.url = "https://example.com/image.png";
+            ConverterRequest.ImageFile base64File = new ConverterRequest.ImageFile();
+            base64File.dataUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+            request.files = List.of(urlFile, base64File);
+
+            String result = service.generateIcs(request);
+            assertNotNull(result);
+            verify(mockClient, times(1)).generateContent(any(), any(), any());
+        }
+
+        // --- helpers ---
+
+        private ConverterRequest buildRequestWithBase64Image() {
+            ConverterRequest request = new ConverterRequest();
+            ConverterRequest.ImageFile file = new ConverterRequest.ImageFile();
+            file.dataUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+            request.files = List.of(file);
+            return request;
+        }
+
+        private ObjectNode buildSuccessResponse(String icsContent) {
+            ObjectNode response = mapper.createObjectNode();
+            ObjectNode candidate = response.putArray("candidates").addObject();
+            candidate.put("finishReason", "STOP");
+            candidate.putObject("content").putArray("parts").addObject().put("text", icsContent);
+            return response;
         }
     }
 }


### PR DESCRIPTION
…ode cleanup

- Extract duplicate cleanIcs() into shared IcsUtils utility; GeminiService and ClaudeService now delegate to it, keeping thin wrapper methods for testability
- Extract duplicate bearerToken() into shared BearerTokenUtil.ensureBearer(); removes identical private methods from TrackingService, NotionService and NotionQuotaService
- Expand GeminiServiceTest with 13 behavior tests in @Nested BehaviorTest class (uses Mockito spy to stub getAccessToken), matching ClaudeServiceTest coverage: cleanIcs variants, happy path, markdown stripping, null date/tz defaults, finishReason != STOP, error field, client throws, no candidates, URL image skipping, and mixed file list handling
- Remove two unused ConverterResponse.error() static factory methods (dead code — ConverterResource throws exceptions instead of returning error envelopes)
- Add @Schema description to TrackingService.Statistics record and its fields
- Add INFO log on successful Notion statistics fetch for observability symmetry

All 84 tests pass.