### PR TITLE
perf: HTTP cache headers, Notion TTL extension, and startup warmup

### DIFF
--- a/src/main/java/com/dime/api/feature/github/GitHubResource.java
+++ b/src/main/java/com/dime/api/feature/github/GitHubResource.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -32,9 +33,11 @@ public class GitHubResource {
     @APIResponse(responseCode = "200", description = "User information retrieved successfully")
     @APIResponse(responseCode = "502", description = "Failed to fetch user from GitHub API")
     @APIResponse(responseCode = "500", description = "Internal server error")
-    public GitHubUser getUser() {
+    public Response getUser() {
         log.info("GET /github/user endpoint called");
-        return gitHubService.getUserInfo();
+        return Response.ok(gitHubService.getUserInfo())
+                .header("Cache-Control", "public, max-age=3600")
+                .build();
     }
 
     @GET
@@ -44,9 +47,11 @@ public class GitHubResource {
     @APIResponse(responseCode = "200", description = "Social accounts retrieved successfully")
     @APIResponse(responseCode = "502", description = "Failed to fetch social accounts from GitHub API")
     @APIResponse(responseCode = "500", description = "Internal server error")
-    public JsonNode getSocialAccounts() {
+    public Response getSocialAccounts() {
         log.info("GET /github/social endpoint called");
-        return gitHubService.getSocialAccounts();
+        return Response.ok(gitHubService.getSocialAccounts())
+                .header("Cache-Control", "public, max-age=3600")
+                .build();
     }
 
     @GET
@@ -57,7 +62,7 @@ public class GitHubResource {
     @APIResponse(responseCode = "400", description = "Invalid months parameter")
     @APIResponse(responseCode = "502", description = "Failed to fetch commits from GitHub API")
     @APIResponse(responseCode = "500", description = "Internal server error")
-    public List<Map<String, Object>> getCommits(@QueryParam("months") String monthsStr) {
+    public Response getCommits(@QueryParam("months") String monthsStr) {
         log.info("GET /github/commits endpoint called with months={}", monthsStr);
 
         int months = 12; // default
@@ -71,6 +76,8 @@ public class GitHubResource {
                 throw new ValidationException("Invalid months parameter. Must be a valid integer.");
             }
         }
-        return gitHubService.getCommits(months);
+        return Response.ok(gitHubService.getCommits(months))
+                .header("Cache-Control", "public, max-age=3600")
+                .build();
     }
 }

--- a/src/main/java/com/dime/api/feature/notion/NotionResource.java
+++ b/src/main/java/com/dime/api/feature/notion/NotionResource.java
@@ -33,6 +33,8 @@ public class NotionResource {
     @APIResponse(responseCode = "500", description = "Internal server error")
     public Response getCmsContent() {
         Map<String, List<NotionService.CmsItem>> content = notionService.getCmsContent();
-        return Response.ok(content).build();
+        return Response.ok(content)
+                .header("Cache-Control", "public, max-age=7200")
+                .build();
     }
 }

--- a/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
+++ b/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
@@ -1,0 +1,49 @@
+package com.dime.api.feature.shared;
+
+import com.dime.api.feature.github.GitHubService;
+import com.dime.api.feature.notion.NotionService;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@ApplicationScoped
+public class CacheWarmup {
+
+    @Inject
+    GitHubService gitHubService;
+
+    @Inject
+    NotionService notionService;
+
+    void onStart(@Observes StartupEvent event) {
+        log.info("Starting async cache warmup...");
+        CompletableFuture.runAsync(this::warmCaches);
+    }
+
+    private void warmCaches() {
+        try {
+            gitHubService.getUserInfo();
+            log.info("GitHub user cache warmed up");
+        } catch (Exception e) {
+            log.warn("Failed to warm GitHub user cache: {}", e.getMessage());
+        }
+        try {
+            gitHubService.getSocialAccounts();
+            log.info("GitHub social cache warmed up");
+        } catch (Exception e) {
+            log.warn("Failed to warm GitHub social cache: {}", e.getMessage());
+        }
+        try {
+            notionService.getCmsContent();
+            log.info("Notion CMS cache warmed up");
+        } catch (Exception e) {
+            log.warn("Failed to warm Notion CMS cache: {}", e.getMessage());
+        }
+        log.info("Cache warmup completed");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -164,7 +164,7 @@ quarkus.http.cors.access-control-max-age=24H
 quarkus.cache.caffeine."github-user-cache".expire-after-write=1H
 quarkus.cache.caffeine."github-social-cache".expire-after-write=1H
 quarkus.cache.caffeine."github-commits-cache".expire-after-write=1H
-quarkus.cache.caffeine."notion-cms-cache".expire-after-write=30M
+quarkus.cache.caffeine."notion-cms-cache".expire-after-write=2H
 quarkus.cache.caffeine."statistics-cache".expire-after-write=5M
 
 # Security Configuration


### PR DESCRIPTION
## Summary

- Add `Cache-Control: public, max-age=3600` to `/github/user`, `/github/social`, `/github/commits` — browsers and CDNs can now cache these responses
- Add `Cache-Control: public, max-age=7200` to `/notion/cms` — matches the new Caffeine TTL
- Extend `notion-cms-cache` Caffeine TTL from 30 minutes to 2 hours — reduces cold-cache hits to Notion API
- Add `CacheWarmup` bean that asynchronously pre-fetches GitHub and Notion data on startup, so the first real user request hits a warm cache instead of waiting for external APIs

## Test plan

- [ ] Hit `https://oo.3dime.com/github/user` and verify `Cache-Control: public, max-age=3600` in response headers
- [ ] Hit `https://oo.3dime.com/notion/cms` and verify `Cache-Control: public, max-age=7200` in response headers
- [ ] Check startup logs for `Cache warmup completed` message
- [ ] Verify portfolio data still loads correctly at `https://portfolio.3dime.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)