### PR TITLE
perf: stale-while-revalidate caching for instant API responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Thumbs.db
 
 # env
 .env
+.claude

--- a/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
+++ b/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
@@ -1,5 +1,6 @@
 package com.dime.api.feature.shared;
 
+import com.dime.api.feature.converter.TrackingService;
 import com.dime.api.feature.github.GitHubService;
 import com.dime.api.feature.notion.NotionService;
 import io.quarkus.runtime.StartupEvent;
@@ -20,6 +21,9 @@ public class CacheWarmup {
     @Inject
     NotionService notionService;
 
+    @Inject
+    TrackingService trackingService;
+
     void onStart(@Observes StartupEvent event) {
         log.info("Starting async cache warmup...");
         CompletableFuture.runAsync(this::warmCaches);
@@ -39,10 +43,22 @@ public class CacheWarmup {
             log.warn("Failed to warm GitHub social cache: {}", e.getMessage());
         }
         try {
+            gitHubService.getCommits(12);
+            log.info("GitHub commits cache warmed up");
+        } catch (Exception e) {
+            log.warn("Failed to warm GitHub commits cache: {}", e.getMessage());
+        }
+        try {
             notionService.getCmsContent();
             log.info("Notion CMS cache warmed up");
         } catch (Exception e) {
             log.warn("Failed to warm Notion CMS cache: {}", e.getMessage());
+        }
+        try {
+            trackingService.getStatistics();
+            log.info("Statistics cache warmed up");
+        } catch (Exception e) {
+            log.warn("Failed to warm statistics cache: {}", e.getMessage());
         }
         log.info("Cache warmup completed");
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -160,12 +160,8 @@ quarkus.http.cors.exposed-headers=Content-Disposition,Content-Type
 quarkus.http.cors.access-control-max-age=24H
 %dev.quarkus.http.cors.origins=*
 
-# Cache Configuration
-quarkus.cache.caffeine."github-user-cache".expire-after-write=1H
-quarkus.cache.caffeine."github-social-cache".expire-after-write=1H
-quarkus.cache.caffeine."github-commits-cache".expire-after-write=1H
-quarkus.cache.caffeine."notion-cms-cache".expire-after-write=2H
-quarkus.cache.caffeine."statistics-cache".expire-after-write=5M
+# Cache: Managed programmatically via Caffeine LoadingCache with stale-while-revalidate
+# (refreshAfterWrite returns stale data instantly while refreshing in background)
 
 # Security Configuration
 quarkus.http.auth.proactive=true

--- a/src/test/java/com/dime/api/feature/converter/TrackingServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/TrackingServiceTest.java
@@ -84,6 +84,7 @@ public class TrackingServiceTest {
             service.trackingDbId = Optional.of("test-db-id");
             service.notionVersion = "2022-02-22";
             service.assignedUserId = Optional.empty();
+            service.initCaches();
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Replace `@CacheResult` with programmatic Caffeine `LoadingCache` using `refreshAfterWrite` so users always get instant responses from cache
- Stale data is served immediately while background refresh happens asynchronously via `ForkJoinPool`
- Extend startup warmup to cover all 5 caches (added commits and statistics)

## Test plan
- [x] All 99 existing tests pass (`mvn test`)
- [ ] Verify startup logs show all 5 caches warming up
- [ ] Hit `/github/user`, `/notion/cms`, `/converter/statistics` — confirm instant responses
- [ ] Check logs for "Fetching..." messages only on startup and after soft TTL access

🤖 Generated with [Claude Code](https://claude.com/claude-code)