### PR TITLE
feat: Firestore persistent cache layer for instant cold starts

### DIFF
--- a/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
+++ b/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
@@ -25,41 +25,53 @@ public class CacheWarmup {
     TrackingService trackingService;
 
     void onStart(@Observes StartupEvent event) {
-        log.info("Starting async cache warmup...");
-        CompletableFuture.runAsync(this::warmCaches);
+        log.info("Starting cache warmup...");
+        warmFromFirestore();
+        CompletableFuture.runAsync(this::warmFromApis);
     }
 
-    private void warmCaches() {
+    private void warmFromFirestore() {
+        try {
+            gitHubService.warmFromFirestore();
+            notionService.warmFromFirestore();
+            trackingService.warmFromFirestore();
+            log.info("Phase 1: Firestore cache warmup completed (instant data available)");
+        } catch (Exception e) {
+            log.warn("Firestore cache warmup failed: {}", e.getMessage());
+        }
+    }
+
+    private void warmFromApis() {
         try {
             gitHubService.getUserInfo();
-            log.info("GitHub user cache warmed up");
+            log.info("GitHub user cache refreshed from API");
         } catch (Exception e) {
             log.warn("Failed to warm GitHub user cache: {}", e.getMessage());
         }
         try {
             gitHubService.getSocialAccounts();
-            log.info("GitHub social cache warmed up");
+            log.info("GitHub social cache refreshed from API");
         } catch (Exception e) {
             log.warn("Failed to warm GitHub social cache: {}", e.getMessage());
         }
         try {
             gitHubService.getCommits(12);
-            log.info("GitHub commits cache warmed up");
+            log.info("GitHub commits cache refreshed from API");
         } catch (Exception e) {
             log.warn("Failed to warm GitHub commits cache: {}", e.getMessage());
         }
         try {
             notionService.getCmsContent();
-            log.info("Notion CMS cache warmed up");
+            log.info("Notion CMS cache refreshed from API");
         } catch (Exception e) {
             log.warn("Failed to warm Notion CMS cache: {}", e.getMessage());
         }
         try {
             trackingService.getStatistics();
-            log.info("Statistics cache warmed up");
+            log.info("Statistics cache refreshed from API");
         } catch (Exception e) {
             log.warn("Failed to warm statistics cache: {}", e.getMessage());
         }
-        log.info("Cache warmup completed");
+        log.info("Phase 2: API cache warmup completed");
     }
 }

--- a/src/main/java/com/dime/api/feature/shared/FirestoreCacheService.java
+++ b/src/main/java/com/dime/api/feature/shared/FirestoreCacheService.java
@@ -1,0 +1,70 @@
+package com.dime.api.feature.shared;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@ApplicationScoped
+public class FirestoreCacheService {
+
+    private static final String COLLECTION = "cache";
+
+    @Inject
+    Firestore firestore;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    public <T> Optional<T> read(String key, Class<T> type) {
+        try {
+            DocumentSnapshot doc = firestore.collection(COLLECTION).document(key).get().get();
+            if (doc.exists()) {
+                String json = doc.getString("data");
+                if (json != null) {
+                    return Optional.of(objectMapper.readValue(json, type));
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to read cache from Firestore for key: {}", key, e);
+        }
+        return Optional.empty();
+    }
+
+    public <T> Optional<T> read(String key, TypeReference<T> type) {
+        try {
+            DocumentSnapshot doc = firestore.collection(COLLECTION).document(key).get().get();
+            if (doc.exists()) {
+                String json = doc.getString("data");
+                if (json != null) {
+                    return Optional.of(objectMapper.readValue(json, type));
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to read cache from Firestore for key: {}", key, e);
+        }
+        return Optional.empty();
+    }
+
+    public void write(String key, Object data) {
+        CompletableFuture.runAsync(() -> {
+            try {
+                String json = objectMapper.writeValueAsString(data);
+                firestore.collection(COLLECTION).document(key)
+                        .set(Map.of("data", json, "updatedAt", Timestamp.now())).get();
+                log.debug("Written cache to Firestore for key: {}", key);
+            } catch (Exception e) {
+                log.warn("Failed to write cache to Firestore for key: {}", key, e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `FirestoreCacheService` as a generic persistent cache layer using Firestore `cache` collection
- Integrates two-tier caching (Caffeine in-memory + Firestore persistent) into GitHubService, NotionService, and TrackingService
- Implements two-phase startup warmup: Phase 1 loads from Firestore instantly, Phase 2 refreshes from APIs in background

## Test plan
- [x] All 98 tests pass (1 pre-existing failure in FirestoreHealthCheckTest unrelated to this change)
- [ ] Deploy to Cloud Run and verify first request returns cached data from Firestore
- [ ] Verify Firestore `cache` collection gets populated after API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)