### PR TITLE
🐳 Add multi-stage Dockerfile for Cloud Run deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Build stage
+FROM maven:3.9-eclipse-temurin-21 AS builder
+
+WORKDIR /build
+
+# Copy pom and source
+COPY pom.xml .
+COPY src ./src
+
+# Build uber-jar, skipping tests
+RUN mvn clean package -DskipTests
+
+# Runtime stage
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+# Copy uber-jar from builder
+COPY --from=builder /build/target/quarkus /app/quarkus
+
+# Set labels
+LABEL service=3dime-api
+LABEL version=1.0.0
+
+# Expose port
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
+# Run the application
+ENTRYPOINT ["sh", "-c", "cd /app && java -Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8080 -jar quarkus/3dime-api-runner.jar"]


### PR DESCRIPTION
Replace buildpack auto-detection with explicit Dockerfile.

**Problem:**
Cloud Run's buildpack auto-detection was still being triggered despite cloudbuild.yaml,
resulting in the Docker API v1.41 vs v1.53 incompatibility error.

**Root Cause:**
When gcloud/Cloud Run auto-detects build system, it uses buildpack for Java projects
regardless of cloudbuild.yaml presence.

**Solution:**
Explicit Dockerfile tells Cloud Run to skip buildpack detection and use standard Docker build.

**Multi-stage Build:**
- **Stage 1 (builder):** maven:3.9-eclipse-temurin-21
  - Compiles Maven project with `mvn clean package -DskipTests`
  - Produces /build/target/quarkus (Quarkus bootstrap + uber-jar)

- **Stage 2 (runtime):** eclipse-temurin:21-jre-alpine (27MB)
  - Minimal production image
  - Copies only built artifacts from stage 1
  - Entrypoint: `sh -c 'java -Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8080 -jar quarkus/3dime-api-runner.jar'`
  - Health check monitoring /health endpoint

**Result:**
Cloud Run will now detect Dockerfile and use standard Docker build, completely
bypassing the buildpack lifecycle that was causing API incompatibility.