### PR TITLE
📄 Add .gcloudignore - requires Cloud Build trigger update

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,21 @@
+# Ignore pom.xml from buildpack detection
+# Force Cloud Build to use Dockerfile instead
+pom.xml
+
+# Standard ignore patterns
+.git
+.gitignore
+.gcloudignore
+README.md
+ROADMAP.md
+.env
+*.md
+.DS_Store
+node_modules/
+__pycache__/
+*.pyc
+.pytest_cache/
+.coverage
+build/
+dist/
+*.egg-info/


### PR DESCRIPTION
Add .gcloudignore to hide pom.xml from buildpack detection.

**Current Issue:**
Cloud Build trigger is using buildpack builder by default, causing the Docker API
v1.41 vs v1.53 incompatibility error. The Dockerfile and cloudbuild.yaml exist
in the repo but aren't being used.

**Solution (2 parts):**

### Part 1: Code Changes (this PR) ✅
Add .gcloudignore to hide pom.xml from buildpack detection, forcing use of Dockerfile.

### Part 2: GCP Console Configuration (manual) ⚠️ 
**You must do this in Cloud Console:**

1. Go to **Cloud Build** > **Triggers**
2. Find and **Edit** the **3dime-api** trigger
3. Under **Build configuration**, select:
   - Option: "Cloud Build configuration file"
   - File location: `cloudbuild.yaml`
4. Click **Save**

**Why this is needed:**
- Cloud Run's default behavior is to auto-detect and use buildpacks
- Without explicit trigger configuration, the custom cloudbuild.yaml is ignored
- Once configured, Cloud Build will execute docker build steps instead of buildpacks

**After Configuration:**
Next deployment will:
1. Use `cloudbuild.yaml` (not buildpack auto-detection)
2. Execute `docker build` with Dockerfile
3. Push image to GCR without API version errors
4. Cloud Run deploys successfully

**Files Ready:**
- ✅ Dockerfile (multi-stage, tested locally)
- ✅ cloudbuild.yaml (explicit docker builder)
- ✅ .gcloudignore (prevents buildpack detection)
- ✅ All security hardening intact