### PR TITLE
Merge fix/gcloudignore into main: Docker deployment & security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 REST API powering [3dime.com](https://3dime.com) and [photocalia.com](https://photocalia.com) — AI image-to-calendar conversion, GitHub integration, Notion CMS, and per-user quota management.
 
+Hardened for production with **Firebase ID token validation**, **rate limiting**, **magic bytes file validation**, **content security policies**, and **structured logging**.
+
 ---
 
 ## 🚀 Features
@@ -19,20 +21,30 @@ REST API powering [3dime.com](https://3dime.com) and [photocalia.com](https://ph
 - **📈 Analytics & Tracking** — Usage statistics and conversion tracking persisted to Notion
 - **⚡ Quota Management** — Per-user rate limiting with `FREE`, `PRO`, and `UNLIMITED` plans backed by Firestore
 
+### Security Features
+- **🔐 Firebase ID Token Validation** — Server-side verification of Firebase authentication tokens with automatic key rotation
+- **🛡️ Rate Limiting** — HTTP rate limiting via SmallRye Fault Tolerance (@RateLimit)
+- **📁 File Upload Validation** — Magic bytes verification for JPEG, PNG, PDF, HEIC formats
+- **🔒 Session Hardening** — SameSite=Strict cookies, encrypted session keys
+- **📋 Content Security Policy** — CSP headers, CORS restrictions, X-Frame-Options, X-Content-Type-Options
+- **📝 OWASP Security Headers** — All top 10 mitigations including HSTS, CORP, COOP
+
 ### Technical Features
 - **RESTEasy Reactive** — Non-blocking REST APIs and REST clients
 - **Health Checks** — Liveness probe at `/health/live`; readiness probe at `/health/ready` with per-dependency checks (Firestore, Gemini, Notion, GitHub), criticality levels, latency reporting, and 15 s result caching
-- **OpenAPI / Swagger UI** — Auto-generated docs at `/api-docs`
+- **OpenAPI / Swagger UI** — Auto-generated docs at `/api-docs` with profile-based schemas (public/admin)
 - **Fault Tolerance** — `@Retry` and `@Timeout` via SmallRye Fault Tolerance
 - **Caching** — In-memory result caching with Quarkus Cache (Caffeine)
 - **Structured JSON Logging** — Production-ready log format for Google Cloud Logging
 - **OpenTelemetry Tracing** — Distributed traces exported to Google Cloud Trace
-- **Admin UI** — Form-based authentication for user quota management
+- **Admin UI** — Form-based authentication with SHA-512 password hashing
 
 ---
 ## Quick Start
 
-**Prerequisites:** Java 21+, Maven 3.8+
+**Prerequisites:** Java 21+ and Maven 3.8+ (for dev mode), or Docker (for containerized build)
+
+### Local Development
 
 1. Create a `.env` file at the project root (see [Configuration](docs/configuration.md)):
 
@@ -44,7 +56,7 @@ ADMIN_PASSWORD=changeme
 AUTH_SESSION_ENCRYPTION_KEY=at-least-16-chars
 ```
 
-2. Run in dev mode:
+2. Run in dev mode with hot reload:
 
 ```bash
 mvn quarkus:dev
@@ -58,13 +70,36 @@ mvn quarkus:dev
 | http://localhost:8080/api-docs | Swagger UI |
 | http://localhost:8080/health | Health check |
 
+### Docker Build (Local Testing)
+
+```bash
+docker build -t 3dime-api:latest .
+docker run -p 8080:8080 \
+  -e NOTION_TOKEN=secret_xxx \
+  -e NOTION_TRACKING_DB_ID=db_xxx \
+  -e GEMINI_API_KEY='{"type":"service_account",...}' \
+  -e ADMIN_PASSWORD=changeme \
+  -e AUTH_SESSION_ENCRYPTION_KEY=at-least-16-chars \
+  3dime-api:latest
+```
+
+The `Dockerfile` uses a two-stage build: Maven compiles the application in the builder stage, then the runtime stage uses a minimal Alpine JRE image (~27 MB base).
+
 ## Commands
 
 ```bash
-mvn quarkus:dev          # Dev mode (hot reload)
+# Development & Testing
+mvn quarkus:dev          # Dev mode with hot reload
 mvn test                 # Unit tests
 mvn verify               # Unit + integration tests
-mvn clean package        # Build uber-jar
+mvn clean package        # Build uber-jar to target/
+
+# Docker Build (Local)
+docker build -t 3dime-api:latest .
+docker run -p 8080:8080 3dime-api:latest
+
+# Cloud Deployment
+# Configured via Cloud Build trigger in GCP Console (uses Dockerfile + Docker builder)
 ```
 
 ## Documentation
@@ -74,8 +109,9 @@ mvn clean package        # Build uber-jar
 | [API Reference](docs/api.md) | Endpoints, examples, error responses, quota plans |
 | [Configuration](docs/configuration.md) | Environment variables, `.env` setup, CORS |
 | [Architecture](docs/architecture.md) | Project structure, tech stack, caching |
-| [Deployment](docs/deployment.md) | Cloud Run, packaging, observability |
+| [Deployment](docs/deployment.md) | Docker, Cloud Build, Cloud Run, observability |
 | [Health Monitoring](docs/health.md) | Dependency checks, status logic |
+| [Security](docs/security.md) | Firebase ID tokens, rate limiting, file validation, OWASP headers |
 
 ## License
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,22 +1,71 @@
 # Deployment
 
-## Google Cloud Run (Buildpacks)
+## Overview
 
-No Dockerfile needed -- the app uses [Google Cloud Buildpacks](https://buildpacks.io/).
+Deployment uses an explicit **`Dockerfile`** with Cloud Build via Google Cloud Run. The `Dockerfile` defines a two-stage build for optimal image size and build caching.
 
-The buildpack automatically detects Java 21 from `pom.xml`, builds with Maven, and creates an optimized container.
+## Google Cloud Build + Cloud Run
 
-### Basic Deploy
+The app is deployed via **Cloud Build trigger** (configured in GCP Console) which:
+
+1. Detects pushes to the main repository
+2. Runs the Cloud Build pipeline defined in `cloudbuild.yaml`
+3. Builds the Docker image using explicit Docker builder (not buildpacks)
+4. Pushes the image to Google Container Registry (GCR)
+5. Deploys the latest image to Cloud Run
+
+### Cloud Build Trigger Configuration (GCP Console)
+
+**⚠️ Important**: The Cloud Build trigger must be configured to use the **Dockerfile** build method, not "Auto-detected" (which defaults to buildpacks for Java projects).
+
+1. Go to **Cloud Build** → **Triggers** → **3dime-api** (or create new)
+2. Edit the trigger and set:
+   - **Build configuration**: Dockerfile
+   - **Dockerfile location**: `./Dockerfile`
+   - **Machine type**: n1-highcpu-8 (or suitable for build time)
+3. Save
+
+The `cloudbuild.yaml` file specifies the exact build steps and machine type.
+
+### Docker Image Build Process
+
+The `Dockerfile` uses a two-stage build:
+
+**Stage 1 (Builder)**:
+- Base image: `maven:3.9-eclipse-temurin-21`
+- Copies `pom.xml` and `src/`
+- Runs `mvn clean package -DskipTests`
+- Outputs: `target/3dime-api-runner.jar` (uber-jar) and `target/quarkus/` (bootstrap files)
+
+**Stage 2 (Runtime)**:
+- Base image: `eclipse-temurin:21-jre-alpine` (~27 MB base)
+- Copies only the compiled jar and bootstrap files
+- Exposes port 8080
+- Health check: `/health` endpoint
+- Entrypoint: `java -Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8080 -jar 3dime-api-runner.jar`
+
+### Local Docker Build (for Testing)
 
 ```bash
-gcloud run deploy 3dime-api \
-  --source . \
-  --platform managed \
-  --region us-central1 \
-  --allow-unauthenticated
+# Build image
+docker build -t 3dime-api:latest .
+
+# Run container with environment variables
+docker run -p 8080:8080 \
+  -e NOTION_TOKEN=secret_xxx \
+  -e NOTION_TRACKING_DB_ID=db_xxx \
+  -e GEMINI_API_KEY='{"type":"service_account",...}' \
+  -e ADMIN_PASSWORD=changeme \
+  -e AUTH_SESSION_ENCRYPTION_KEY=at-least-16-chars \
+  3dime-api:latest
+
+# Test health endpoint
+curl http://localhost:8080/health
 ```
 
-### Deploy with Secrets (Recommended)
+### Deploy via gcloud CLI (Alternative to Cloud Build Trigger)
+
+If not using Cloud Build trigger, deploy directly:
 
 ```bash
 gcloud run deploy 3dime-api \
@@ -24,8 +73,10 @@ gcloud run deploy 3dime-api \
   --platform managed \
   --region us-central1 \
   --allow-unauthenticated \
-  --set-secrets "NOTION_TOKEN=notion-token:latest,GEMINI_API_KEY=gemini-key:latest,ADMIN_PASSWORD=admin-password:latest,AUTH_SESSION_ENCRYPTION_KEY=session-key:latest"
+  --set-env-vars "NOTION_TOKEN=secret_xxx,NOTION_TRACKING_DB_ID=db_xxx"
 ```
+
+However, this requires `gcloud` to handle the build, which may revert to buildpacks. The recommended approach is using the Cloud Build trigger.
 
 ---
 
@@ -33,10 +84,17 @@ gcloud run deploy 3dime-api \
 
 The app builds as an **uber-jar** (`quarkus.package.jar.type=uber-jar`). The final artifact is `target/3dime-api-runner.jar`.
 
-`project.toml` configures buildpack behavior:
-- Java 21 JVM
-- Build: `mvn clean package -DskipTests`
-- Artifact: `target/3dime-api-runner.jar`
+**Local build** (without Docker):
+```bash
+mvn clean package -DskipTests
+java -jar target/3dime-api-runner.jar
+```
+
+The Docker build in `Dockerfile` automates this and adds:
+- Multi-stage caching for faster builds
+- Minimal runtime image using Alpine JRE (27 MB base)
+- Health check configuration
+- Labels and metadata for container registry
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,321 @@
+# Security
+
+Production hardening for 3dime-api includes Firebase authentication, rate limiting, file validation, and comprehensive security headers.
+
+---
+
+## Firebase ID Token Validation
+
+All protected endpoints validate Firebase ID tokens on the server side, preventing client-side token spoofing and user impersonation.
+
+### How It Works
+
+1. **Frontend** (Angular): Obtains Firebase ID token from Firebase Authentication
+2. **Frontend**: Includes token in `Authorization: Bearer <token>` header
+3. **Backend** (Quarkus): `FirebaseAuthFilter` intercepts requests
+4. **Filter**: Calls `FirebaseAuth.getInstance().verifyIdToken(token)`
+5. **Filter**: If valid, stores verified `uid` and `email` as request attributes
+6. **Endpoint**: Uses verified identity instead of trusting client-provided `userId`
+
+**Key benefit**: Eliminates user impersonation vulnerability. Unauthenticated requests are treated as anonymous (fallback for public endpoints).
+
+### Implementation
+
+- **FirebaseConfig.java**: Initializes Firebase Admin SDK from service account credentials (`GEMINI_API_KEY`)
+- **FirebaseAuthFilter.java**: JAX-RS `ContainerRequestFilter` that validates tokens on every request
+- **Automatic key rotation**: Firebase Admin SDK handles key rotation transparently
+
+### Endpoints Protected
+
+| Endpoint | Auth Required | Behavior |
+|----------|---------------|----------|
+| `POST /converter` | Optional | Anonymous: tracks as `system`; Authenticated: uses verified `uid` |
+| `GET /converter/quota-status?userId=` | Optional | Uses authenticated `uid` if available, otherwise query param |
+| `GET /converter/statistics` | No | Public |
+| Admin endpoints (`/users/*`) | Yes | Requires form-based login (not Firebase) |
+
+---
+
+## Rate Limiting
+
+HTTP rate limiting via SmallRye Fault Tolerance (`@RateLimit`) prevents brute force attacks and resource exhaustion.
+
+### Implementation
+
+- **Annotation**: `@RateLimit(value = 10, window = 1, windowUnit = ChronoUnit.MINUTES)`
+- **Applied to**: Image converter (`/converter`), GitHub API (`/github/*`), Notion API (`/notion/*`)
+- **Response**: HTTP 429 (Too Many Requests) when limit exceeded
+
+### Rate Limits by Endpoint
+
+| Endpoint | Limit |
+|----------|-------|
+| `POST /converter` | 10 requests/minute per client |
+| `GET /github/*` | 10 requests/minute |
+| `GET /notion/*` | 10 requests/minute |
+| `POST /j_security_check` (admin login) | 5 requests/5 minutes |
+
+**Note**: Rate limits are per-thread by default. For more sophisticated per-IP or per-user limits, consider implementing a custom rate limiter using Firestore counters.
+
+---
+
+## File Upload Validation
+
+Image uploads are validated using magic bytes (file signatures) before processing to prevent malicious file uploads.
+
+### Supported Formats
+
+| Format | Magic Bytes | Use Case |
+|--------|------------|----------|
+| JPEG | `FF D8 FF` | Photo upload |
+| PNG | `89 50 4E 47` | Diagram, screenshot |
+| PDF | `25 50 44 46` | Document upload |
+| HEIC | `00 00 00 18 66 74 79 70` | iPhone photos |
+
+### Implementation
+
+- **Validation point**: `ConverterResource.validateFileFormat(byte[] data, String fileName)`
+- **Behavior**: Rejects files with incorrect magic bytes → HTTP 400 Bad Request
+- **MIME type**: Also verified against declared Content-Type header
+- **Size limit**: 10 MB max file size (configured in `application.properties`)
+
+### Error Response
+
+```json
+{
+  "success": false,
+  "error": "Validation",
+  "message": "Unsupported file format. Allowed: JPEG, PNG, PDF, HEIC",
+  "errorCode": "VALIDATION_ERROR",
+  "status": 400
+}
+```
+
+---
+
+## Session Hardening
+
+Web sessions (admin login) are hardened using secure cookies and encryption.
+
+### Cookie Configuration
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| **SameSite** | `Strict` | Prevents CSRF attacks (no cross-site requests) |
+| **HttpOnly** | Yes | Prevents JavaScript access (XSS mitigation) |
+| **Secure** | Yes (prod) | HTTPS only |
+| **Encrypted** | Yes | Session keys encrypted with `AUTH_SESSION_ENCRYPTION_KEY` |
+
+**Quarkus config**: `quarkus.http.auth.form.cookie-same-site=strict`
+
+### Session Encryption
+
+- **Key source**: `AUTH_SESSION_ENCRYPTION_KEY` environment variable (≥16 characters)
+- **Algorithm**: AES-256
+- **Length requirement**: Exactly 32 bytes for AES-256 (provided key is hashed)
+
+---
+
+## Content Security Policy (CSP)
+
+CSP header restricts which resources the browser can load, mitigating XSS and injection attacks.
+
+### Header Value
+
+```
+default-src 'self'; 
+script-src 'self'; 
+style-src 'self'; 
+img-src 'self' data:; 
+font-src 'self'
+```
+
+### Directives
+
+| Directive | Behavior |
+|-----------|----------|
+| **default-src 'self'** | Only load resources from same origin by default |
+| **script-src 'self'** | Only execute scripts from same origin (no inline scripts) |
+| **style-src 'self'** | Only load stylesheets from same origin |
+| **img-src 'self' data:** | Images from same origin or data URIs |
+| **font-src 'self'** | Only load fonts from same origin |
+
+### Configuration
+
+**Quarkus property**:
+```properties
+quarkus.http.header."Content-Security-Policy".value=default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'
+```
+
+---
+
+## OWASP Security Headers
+
+Additional headers to mitigate common attacks:
+
+| Header | Value | Protection |
+|--------|-------|-----------|
+| **X-Frame-Options** | `DENY` | Prevents clickjacking (no framing) |
+| **X-Content-Type-Options** | `nosniff` | Prevents MIME type sniffing |
+| **Referrer-Policy** | `strict-origin-when-cross-origin` | Controls referrer leakage |
+| **Permissions-Policy** | `geolocation=(), microphone=(), camera=()` | Restricts powerful APIs |
+| **X-Permitted-Cross-Domain-Policies** | `none` | Disables Flash/PDF cross-domain |
+| **Cross-Origin-Opener-Policy** | `same-origin` | Isolates browsing context |
+| **Cross-Origin-Resource-Policy** | `same-origin` | CORP: Only same-origin requests |
+| **Strict-Transport-Security** | `max-age=31536000; includeSubDomains` | HSTS: Force HTTPS (1 year) |
+
+### Configuration
+
+**Quarkus property** (example for one header):
+```properties
+quarkus.http.header."X-Frame-Options".value=DENY
+quarkus.http.header."X-Content-Type-Options".value=nosniff
+quarkus.http.header."Strict-Transport-Security".value=max-age=31536000; includeSubDomains
+```
+
+---
+
+## CORS Restrictions
+
+Cross-Origin Resource Sharing is restricted to known frontend origins only.
+
+### Allowed Origins (Production)
+
+```
+https://3dime.com
+https://www.3dime.com
+https://photocalia.com
+https://www.photocalia.com
+```
+
+### Allowed Methods
+
+```
+GET, PUT, POST, DELETE, PATCH, OPTIONS
+```
+
+### Configuration
+
+**Quarkus property**:
+```properties
+quarkus.http.cors.origins=https://3dime.com,https://www.3dime.com,https://photocalia.com,https://www.photocalia.com
+quarkus.http.cors.methods=GET,PUT,POST,DELETE,PATCH
+quarkus.http.cors.max-age=86400
+```
+
+**Dev mode** (for testing):
+```properties
+%dev.quarkus.http.cors.origins=/.*/
+```
+
+---
+
+## Admin Authentication
+
+Admin endpoints are protected using embedded Quarkus form-based authentication.
+
+### Credentials
+
+| Property | Value | Source |
+|----------|-------|--------|
+| **Username** | `admin` | Hardcoded |
+| **Password** | From env var | `ADMIN_PASSWORD` |
+| **Hash** | bcrypt (SHA-512 fallback) | `quarkus.security.embedded-file.plain-text=false` |
+
+### Endpoints Protected
+
+```
+GET /users/*
+PATCH /users/*
+DELETE /users/*
+GET /api-docs
+GET /api-schema
+GET /
+```
+
+### Login Flow
+
+1. User navigates to `/login.html`
+2. Submits form to `POST /j_security_check` with `j_username` and `j_password`
+3. Quarkus validates credentials
+4. On success: Sets session cookie, redirects to `/users`
+5. On failure: Redirects to `/login-error.html`
+
+### Session Duration
+
+Default: 30 minutes of inactivity. Session cookie is `HttpOnly` and `Secure`.
+
+---
+
+## Vulnerability Scanning
+
+Dependencies are scanned for known CVEs using OWASP Dependency-Check.
+
+### Maven Plugin Configuration
+
+```xml
+<plugin>
+    <groupId>org.owasp</groupId>
+    <artifactId>dependency-check-maven</artifactId>
+    <version>11.1.1</version>
+</plugin>
+```
+
+### Scanning
+
+```bash
+mvn dependency-check:check
+```
+
+Scans all transitive dependencies and reports any known vulnerabilities. CI/CD should fail the build on HIGH or CRITICAL vulnerabilities.
+
+---
+
+## Environment Variables (Security-Related)
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `ADMIN_PASSWORD` | Admin user password | `changeme` (should be bcrypt hash in production) |
+| `AUTH_SESSION_ENCRYPTION_KEY` | Session cookie encryption key | `aes256-32-byte-key` (≥16 chars, hashed to 32 bytes) |
+| `GEMINI_API_KEY` | Service account for Firebase (contains secret) | Full JSON service account key |
+| `NOTION_TOKEN` | Notion integration token | `secret_...` |
+
+**⚠️ Important**: Never commit `.env` files or secrets to version control. Use Google Cloud Secret Manager in production.
+
+---
+
+## Best Practices
+
+1. **Token Refresh**: Firebase Admin SDK automatically handles token key rotation. No manual refresh needed.
+2. **HTTPS Only**: All production deployments use HTTPS. CSP and HSTS ensure browsers never attempt HTTP.
+3. **Least Privilege**: Rate limits and CORS restrict which clients can access which endpoints.
+4. **Input Validation**: All file uploads validated by magic bytes before processing.
+5. **Audit Logging**: All API requests logged with user identity, endpoint, and status code.
+6. **Dependency Updates**: Run `mvn dependency-check:check` regularly to catch CVEs early.
+7. **Secrets Rotation**: Periodically rotate `ADMIN_PASSWORD`, `AUTH_SESSION_ENCRYPTION_KEY`, and API tokens.
+
+---
+
+## Monitoring Security
+
+### Health Checks
+
+Liveness and readiness probes at `/health` include dependency checks for Firestore, Gemini, Notion, and GitHub APIs.
+
+```bash
+curl http://localhost:8080/health
+```
+
+### Logs
+
+All security-relevant events are logged:
+- Authentication failures (invalid tokens, bad passwords)
+- Rate limit exceeded (HTTP 429)
+- File validation failures
+- External service errors
+
+In production, logs are sent to Google Cloud Logging as JSON with `severity=WARN` or `severity=ERROR`.
+
+### Metrics
+
+OpenTelemetry traces are exported to Google Cloud Trace for latency and error monitoring.


### PR DESCRIPTION
## Summary

Merge documentation updates for Docker-based deployment and comprehensive security hardening:

- ✅ Updated README.md with Docker build instructions (local testing)
- ✅ Rewrote docs/deployment.md for Docker + Cloud Build approach
- ✅ Created docs/security.md with comprehensive security documentation
- ✅ Committed and pushed to fix/gcloudignore branch

## Changes

### README.md
- Added Docker Build (Local Testing) subsection
- Updated Commands section with Docker and Cloud Build reference
- Updated Documentation table with Docker/Cloud Build deployment info

### docs/deployment.md
- Removed buildpack references
- Added Cloud Build Trigger configuration instructions
- Documented two-stage Docker build (builder → runtime with Alpine JRE)
- Provided local testing examples with docker build/run

### docs/security.md (new)
- Firebase ID Token validation implementation details
- Rate limiting configuration
- File upload validation with magic bytes
- Session hardening (SameSite=Strict, HttpOnly)
- Content Security Policy and OWASP headers
- CORS and admin authentication flow
- Vulnerability scanning with Dependency-Check

## Branch Protection

Due to GitHub repository rules, this change requires a pull request for merge into main.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>