### PR TITLE
fix: resolve stale Notion CMS data by forcing API refresh on startup

### DIFF
--- a/src/main/java/com/dime/api/feature/notion/NotionResource.java
+++ b/src/main/java/com/dime/api/feature/notion/NotionResource.java
@@ -37,4 +37,15 @@ public class NotionResource {
                 .header("Cache-Control", "public, max-age=7200")
                 .build();
     }
+
+    @GET
+    @Path("/cms/refresh")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Forced refresh of CMS content", description = "Bypasses cache and fetches fresh content from Notion CMS database")
+    @APIResponse(responseCode = "200", description = "Content refreshed successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Map.class)))
+    @APIResponse(responseCode = "502", description = "Failed to fetch content from Notion API")
+    public Response refreshCmsContent() {
+        Map<String, List<NotionService.CmsItem>> content = notionService.refreshCmsContent();
+        return Response.ok(content).build();
+    }
 }

--- a/src/main/java/com/dime/api/feature/notion/NotionService.java
+++ b/src/main/java/com/dime/api/feature/notion/NotionService.java
@@ -60,6 +60,13 @@ public class NotionService {
         return cmsCache.get("default");
     }
 
+    public Map<String, List<CmsItem>> refreshCmsContent() {
+        log.info("Forcing refresh of Notion CMS content from API...");
+        Map<String, List<CmsItem>> content = fetchCmsContent();
+        cmsCache.put("default", content);
+        return content;
+    }
+
     public void warmFromFirestore() {
         if (firestoreCacheService == null) return;
         firestoreCacheService.read("notion-cms", new TypeReference<Map<String, List<CmsItem>>>() {})
@@ -92,6 +99,7 @@ public class NotionService {
             Map<String, List<CmsItem>> groupedContent = new HashMap<>();
 
             if (response.has("results") && response.get("results").isArray()) {
+                log.info("Parsing {} results from Notion", response.get("results").size());
                 for (JsonNode page : response.get("results")) {
                     JsonNode props = page.get("properties");
                     if (props == null)
@@ -107,6 +115,9 @@ public class NotionService {
                     groupedContent.computeIfAbsent(category, k -> new ArrayList<>()).add(item);
                 }
             }
+
+            int totalItems = groupedContent.values().stream().mapToInt(List::size).sum();
+            log.info("Fetch complete. Found {} items in {} categories.", totalItems, groupedContent.size());
 
             if (firestoreCacheService != null) firestoreCacheService.write("notion-cms", groupedContent);
             return groupedContent;

--- a/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
+++ b/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
@@ -61,7 +61,7 @@ public class CacheWarmup {
             log.warn("Failed to warm GitHub commits cache: {}", e.getMessage());
         }
         try {
-            notionService.getCmsContent();
+            notionService.refreshCmsContent();
             log.info("Notion CMS cache refreshed from API");
         } catch (Exception e) {
             log.warn("Failed to warm Notion CMS cache: {}", e.getMessage());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -193,7 +193,7 @@ quarkus.http.auth.permission.public-ui.paths=/login.html,/login-error.html,/j_se
 quarkus.http.auth.permission.public-ui.policy=permit
 
 # Secure Admin paths (users tools, home redirect, and swagger documentation)
-quarkus.http.auth.permission.admin.paths=/users/*,/,/api-docs/*,/api-docs,/api-schema/*,/q/*
+quarkus.http.auth.permission.admin.paths=/users/*,/,/api-docs/*,/api-docs,/api-schema/*,/q/*,/notion/cms/refresh
 quarkus.http.auth.permission.admin.policy=admin-policy
 
 GOOGLE_CLOUD_PROJECT=image-to-ics

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -203,3 +203,7 @@ quarkus.swagger-ui.theme=flattop
 quarkus.swagger-ui.validator-url=none
 
 quarkus.google.cloud.service-account-location=${GOOGLE_APPLICATION_CREDENTIALS:}
+ 
+ # HTTP Access Logging (for terminal request logs)
+ quarkus.http.access-log.enabled=true
+ quarkus.http.access-log.pattern=common


### PR DESCRIPTION
This pull request introduces a new API endpoint to force-refresh CMS content from the Notion database, improves logging for CMS fetch operations, and updates cache warmup logic to use the new refresh method. It also secures the new endpoint for admin access. The most important changes are grouped below:

**New CMS Refresh Functionality:**

* Added a new `refreshCmsContent()` endpoint in `NotionResource.java` to allow forced refresh of CMS content from Notion, bypassing the cache. This endpoint is documented and returns the latest content.
* Implemented the `refreshCmsContent()` method in `NotionService.java`, which fetches fresh content from Notion, updates the cache, and returns the new data.

**Logging and Observability Improvements:**

* Enhanced logging in `fetchCmsContent()` to log the number of results parsed from Notion and provide a summary of fetched items and categories. [[1]](diffhunk://#diff-572387fdd8588cbb00c35fd23a860490f3b2fdf8b36a469a5b08808c94cea96fR102) [[2]](diffhunk://#diff-572387fdd8588cbb00c35fd23a860490f3b2fdf8b36a469a5b08808c94cea96fR119-R121)

**Cache Warmup and Security Updates:**

* Updated cache warmup logic in `CacheWarmup.java` to use the new `refreshCmsContent()` method instead of the cached version, ensuring the cache is always refreshed from the API during warmup.
* Updated `application.properties` to restrict access to the new `/notion/cms/refresh` endpoint to admin users only.…and adding /refresh endpoint