### PR TITLE
ci: add automatic Cloud Run deploy step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,12 +22,28 @@ steps:
       - 'push'
       - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:latest'
 
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    args:
+      - 'gcloud'
+      - 'run'
+      - 'deploy'
+      - '$_SERVICE_NAME'
+      - '--image'
+      - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:$SHORT_SHA'
+      - '--region'
+      - '$_REGION'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+
 images:
   - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:latest'
 
 substitutions:
   _SERVICE_NAME: '3dime-api'
+  _REGION: 'us-central1'
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- Add Cloud Run deploy step to `cloudbuild.yaml` so builds automatically deploy to production after pushing the image
- Add `_REGION` substitution variable (`us-central1`)

## Test plan
- [ ] Verify Cloud Build service account has **Cloud Run Admin** and **Service Account User** roles
- [ ] Merge and confirm the next Cloud Build trigger deploys the new image to Cloud Run

🤖 Generated with [Claude Code](https://claude.com/claude-code)