### PR TITLE
fix: remove pom.xml from .gcloudignore and clean up cloudbuild

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,7 +1,3 @@
-# Ignore pom.xml from buildpack detection
-# Force Cloud Build to use Dockerfile instead
-pom.xml
-
 # Standard ignore patterns
 .git
 .gitignore

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,28 +22,12 @@ steps:
       - 'push'
       - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:latest'
 
-  # Deploy to Cloud Run
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    args:
-      - 'gcloud'
-      - 'run'
-      - 'deploy'
-      - '$_SERVICE_NAME'
-      - '--image'
-      - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:$SHORT_SHA'
-      - '--region'
-      - '$_REGION'
-      - '--platform'
-      - 'managed'
-      - '--allow-unauthenticated'
-
 images:
   - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:latest'
 
 substitutions:
   _SERVICE_NAME: '3dime-api'
-  _REGION: 'us-central1'
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- Remove `pom.xml` from `.gcloudignore` — it was breaking Docker builds on Cloud Build
- Revert the Cloud Run deploy step from `cloudbuild.yaml` — not needed since auto-deploy triggers handle deployment

## Test plan
- [ ] Merge and verify Cloud Build trigger succeeds on next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)