### PR TITLE
ci: add Cloud Run deploy step to cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,12 +22,28 @@ steps:
       - 'push'
       - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:latest'
 
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    args:
+      - 'gcloud'
+      - 'run'
+      - 'deploy'
+      - '$_CLOUD_RUN_SERVICE'
+      - '--image'
+      - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:$SHORT_SHA'
+      - '--region'
+      - '$_REGION'
+      - '--platform'
+      - 'managed'
+
 images:
   - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:latest'
 
 substitutions:
   _SERVICE_NAME: '3dime-api'
+  _CLOUD_RUN_SERVICE: 'dime-api'
+  _REGION: 'europe-west1'
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- Add Cloud Run deploy step to `cloudbuild.yaml` (targets `dime-api` in `europe-west1`)
- Replaced the old broken trigger (inline config, wrong image path) with a new one that uses `cloudbuild.yaml`

## What was wrong
The old trigger only built and pushed the image to `gcr.io/image-to-ics/github.com/m-idriss/3dime-api` but never deployed to Cloud Run. The Cloud Run service uses `gcr.io/image-to-ics/3dime-api`.

## Test plan
- [ ] Merge this PR and verify Cloud Build triggers, builds, and deploys to Cloud Run automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)