### PR TITLE
fix: remove payment_intent_data incompatible with subscription mode c…

### DIFF
--- a/src/main/java/com/dime/api/feature/subscription/StripeService.java
+++ b/src/main/java/com/dime/api/feature/subscription/StripeService.java
@@ -78,10 +78,6 @@ public class StripeService {
                                 .putMetadata("userId", userId)
                                 .putMetadata("planId", planId)
                                 .build())
-                .setPaymentIntentData(
-                        SessionCreateParams.PaymentIntentData.builder()
-                                .setStatementDescriptorSuffix("PHOTOCALIA")
-                                .build())
                 .build();
 
         Session session = Session.create(params);


### PR DESCRIPTION
This pull request makes a small change to the `StripeService.java` file by removing the custom statement descriptor suffix from the Stripe checkout session creation. This simplifies the payment intent configuration and relies on default behavior.…heckout

https://claude.ai/code/session_01Xy8uwDLEgrcVbzg9uxuku7