### PR TITLE
feat: activate subscription and donation checkout features

### DIFF
--- a/src/main/java/com/dime/api/feature/donation/DonationRequest.java
+++ b/src/main/java/com/dime/api/feature/donation/DonationRequest.java
@@ -1,0 +1,14 @@
+package com.dime.api.feature.donation;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record DonationRequest(
+        @NotBlank(message = "productId is required")
+        @Pattern(regexp = "coffee|snack|meal", message = "productId must be 'coffee', 'snack' or 'meal'")
+        String productId,
+
+        @Email(message = "email must be valid")
+        String email
+) {}

--- a/src/main/java/com/dime/api/feature/donation/DonationResource.java
+++ b/src/main/java/com/dime/api/feature/donation/DonationResource.java
@@ -1,0 +1,52 @@
+package com.dime.api.feature.donation;
+
+import com.dime.api.feature.subscription.CheckoutResponse;
+import com.dime.api.feature.subscription.StripeService;
+import com.stripe.exception.StripeException;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.Map;
+
+@Slf4j
+@Path("/donations")
+@Tag(name = "donations", description = "One-off donation checkout")
+@Extension(name = "x-smallrye-profile-public", value = "")
+public class DonationResource {
+
+    @Inject
+    StripeService stripeService;
+
+    @POST
+    @Path("/checkout")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Create donation Checkout Session", description = "Creates a Stripe one-off payment session for coffee, snack or meal and returns the hosted payment URL")
+    public Response createCheckout(@Valid DonationRequest request) {
+        log.info("Creating donation checkout session for product {}", request.productId());
+
+        try {
+            String sessionUrl = stripeService.createDonationSession(request.productId(), request.email());
+            return Response.ok(new CheckoutResponse(sessionUrl)).build();
+        } catch (StripeException e) {
+            log.error("Stripe error creating donation checkout for product {}: {}", request.productId(), e.getMessage(), e);
+            return Response.status(Response.Status.BAD_GATEWAY)
+                    .entity(Map.of("error", "Payment provider error. Please try again.", "code", e.getCode()))
+                    .build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", e.getMessage()))
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dime/api/feature/subscription/StripeService.java
+++ b/src/main/java/com/dime/api/feature/subscription/StripeService.java
@@ -39,11 +39,26 @@ public class StripeService {
     @ConfigProperty(name = "stripe.price.business.yearly")
     Optional<String> priceBusinessYearly;
 
+    @ConfigProperty(name = "stripe.price.coffee")
+    Optional<String> priceCoffee;
+
+    @ConfigProperty(name = "stripe.price.snack")
+    Optional<String> priceSnack;
+
+    @ConfigProperty(name = "stripe.price.meal")
+    Optional<String> priceMeal;
+
     @ConfigProperty(name = "stripe.success.url", defaultValue = "https://photocalia.com/subscription/success")
     String successUrl;
 
     @ConfigProperty(name = "stripe.cancel.url", defaultValue = "https://photocalia.com/pricing")
     String cancelUrl;
+
+    @ConfigProperty(name = "stripe.donation.success.url", defaultValue = "https://photocalia.com/donation/success")
+    String donationSuccessUrl;
+
+    @ConfigProperty(name = "stripe.donation.cancel.url", defaultValue = "https://photocalia.com/pricing")
+    String donationCancelUrl;
 
     @PostConstruct
     void init() {
@@ -83,6 +98,33 @@ public class StripeService {
         Session session = Session.create(params);
         log.info("Created Stripe Checkout Session {} for user {} (plan={}, cycle={})",
                 session.getId(), userId, planId, billingCycle);
+        return session.getUrl();
+    }
+
+    public String createDonationSession(String productId, String email) throws StripeException {
+        String priceId = switch (productId) {
+            case "coffee" -> priceCoffee.orElseThrow(() -> new IllegalStateException("STRIPE_PRICE_COFFEE not configured"));
+            case "snack" -> priceSnack.orElseThrow(() -> new IllegalStateException("STRIPE_PRICE_SNACK not configured"));
+            case "meal" -> priceMeal.orElseThrow(() -> new IllegalStateException("STRIPE_PRICE_MEAL not configured"));
+            default -> throw new IllegalArgumentException("Unknown donation product: " + productId);
+        };
+
+        SessionCreateParams.Builder builder = SessionCreateParams.builder()
+                .setMode(SessionCreateParams.Mode.PAYMENT)
+                .setSuccessUrl(donationSuccessUrl + "?session_id={CHECKOUT_SESSION_ID}")
+                .setCancelUrl(donationCancelUrl)
+                .addLineItem(
+                        SessionCreateParams.LineItem.builder()
+                                .setPrice(priceId)
+                                .setQuantity(1L)
+                                .build());
+
+        if (email != null && !email.isBlank()) {
+            builder.setCustomerEmail(email);
+        }
+
+        Session session = Session.create(builder.build());
+        log.info("Created donation Checkout Session {} for product {}", session.getId(), productId);
         return session.getUrl();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -112,8 +112,16 @@ stripe.price.business.yearly=${STRIPE_PRICE_BUSINESS_YEARLY:}
 %test.stripe.price.pro.yearly=price_test_pro_yearly
 %test.stripe.price.business.monthly=price_test_business_monthly
 %test.stripe.price.business.yearly=price_test_business_yearly
+stripe.price.coffee=${STRIPE_PRICE_COFFEE:}
+stripe.price.snack=${STRIPE_PRICE_SNACK:}
+stripe.price.meal=${STRIPE_PRICE_MEAL:}
+%test.stripe.price.coffee=price_test_coffee
+%test.stripe.price.snack=price_test_snack
+%test.stripe.price.meal=price_test_meal
 stripe.success.url=${STRIPE_SUCCESS_URL:https://photocalia.com/subscription/success}
 stripe.cancel.url=${STRIPE_CANCEL_URL:https://photocalia.com/pricing}
+stripe.donation.success.url=${STRIPE_DONATION_SUCCESS_URL:https://photocalia.com/donation/success}
+stripe.donation.cancel.url=${STRIPE_DONATION_CANCEL_URL:https://photocalia.com/pricing}
 
 # Quota Limits per Plan
 quota.limit.free=${QUOTA_LIMIT_FREE:3}
@@ -209,7 +217,7 @@ quarkus.security.users.embedded.roles.admin=admin
 quarkus.http.auth.policy.admin-policy.roles-allowed=admin
 
 # Permit public API endpoints for frontends
-quarkus.http.auth.permission.public-api.paths=/v1/converter/*,/v1/github/*,/v1/notion/*,/v1/subscriptions/*,/v1/webhooks/*
+quarkus.http.auth.permission.public-api.paths=/v1/converter/*,/v1/github/*,/v1/notion/*,/v1/subscriptions/*,/v1/webhooks/*,/v1/donations/*
 quarkus.http.auth.permission.public-api.policy=permit
 
 # Permit login components


### PR DESCRIPTION
## Summary
- Fix Stripe checkout for subscriptions: remove `payment_intent_data` incompatible with `SUBSCRIPTION` mode
- Add `POST /v1/donations/checkout` endpoint for one-off coffee/snack/meal payments
- Wire donation price IDs via env vars (`STRIPE_PRICE_COFFEE`, `STRIPE_PRICE_SNACK`, `STRIPE_PRICE_MEAL`)
- Expose `/v1/donations/*` as a public API path

## Test plan
- [ ] `POST /v1/subscriptions` returns a valid Stripe checkout URL
- [ ] `POST /v1/donations/checkout` with `productId: coffee|snack|meal` returns a valid Stripe checkout URL
- [ ] Add `STRIPE_PRICE_COFFEE`, `STRIPE_PRICE_SNACK`, `STRIPE_PRICE_MEAL` env vars to Cloud Run

https://claude.ai/code/session_01Xy8uwDLEgrcVbzg9uxuku7