### PR TITLE
fix: place Swagger UI under /v1 prefix for consistency

### DIFF
--- a/src/main/java/com/dime/api/feature/shared/RootResource.java
+++ b/src/main/java/com/dime/api/feature/shared/RootResource.java
@@ -15,7 +15,7 @@ public class RootResource {
     @Operation(hidden = true)
     public Response redirectToApiDocs() {
         return Response
-                .temporaryRedirect(URI.create("/api-docs"))
+                .temporaryRedirect(URI.create("/v1/api-docs"))
                 .build();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -142,7 +142,7 @@ quarkus.index-dependency.google-cloud-firestore.artifact-id=google-cloud-firesto
 quarkus.index-dependency.protobuf-java.group-id=com.google.protobuf
 quarkus.index-dependency.protobuf-java.artifact-id=protobuf-java
 
-quarkus.swagger-ui.path=/api-docs
+quarkus.swagger-ui.path=/v1/api-docs
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.deep-linking=false
 quarkus.swagger-ui.footer=&#169; 2026. This is a Microservice ${quarkus.application.name} by 3dime. <a href="/v1/logout" style="display: inline-block; padding: 4px 12px; border-radius: 6px; background: #6366f1; color: white; text-decoration: none; font-size: 12px; font-weight: 600; margin-left: 15px; transition: opacity 0.2s;" onmouseover="this.style.opacity='0.8'" onmouseout="this.style.opacity='1'">Logout</a>
@@ -159,10 +159,10 @@ quarkus.smallrye-openapi.info-contact-url=https://github.com/m-idriss
 quarkus.smallrye-openapi.info-contact-email=contact@3dime.com
 
 # OpenAPI Additional Documentation Groups
-quarkus.smallrye-openapi.all.path=/api-schema
-quarkus.smallrye-openapi.public.path=/api-schema/public
+quarkus.smallrye-openapi.all.path=/v1/api-schema
+quarkus.smallrye-openapi.public.path=/v1/api-schema/public
 quarkus.smallrye-openapi.public.scan-profiles=public
-quarkus.smallrye-openapi.admin.path=/api-schema/admin
+quarkus.smallrye-openapi.admin.path=/v1/api-schema/admin
 quarkus.smallrye-openapi.admin.scan-profiles=admin
 
 # Swagger UI Multiple Groups Configuration
@@ -204,7 +204,7 @@ quarkus.http.auth.proactive=true
 quarkus.http.auth.form.enabled=true
 quarkus.http.auth.form.login-page=/login.html
 quarkus.http.auth.form.error-page=/login-error.html
-quarkus.http.auth.form.landing-page=/api-docs
+quarkus.http.auth.form.landing-page=/v1/api-docs
 quarkus.http.auth.form.cookie-same-site=strict
 quarkus.http.auth.form.cookie-name=quarkus-credential
 
@@ -225,7 +225,7 @@ quarkus.http.auth.permission.public-ui.paths=/login.html,/login-error.html,/j_se
 quarkus.http.auth.permission.public-ui.policy=permit
 
 # Secure Admin paths (users tools, home redirect, and swagger documentation)
-quarkus.http.auth.permission.admin.paths=/v1/users/*,/v1,/v1/,/api-docs/*,/api-docs,/api-schema/*,/q/*,/v1/notion/cms/refresh
+quarkus.http.auth.permission.admin.paths=/v1/users/*,/v1,/v1/,/v1/api-docs/*,/v1/api-docs,/v1/api-schema/*,/q/*,/v1/notion/cms/refresh
 quarkus.http.auth.permission.admin.policy=admin-policy
 
 GOOGLE_CLOUD_PROJECT=image-to-ics


### PR DESCRIPTION
## Summary
- Move Swagger UI from `/api-docs` to `/v1/api-docs`
- Move OpenAPI schemas from `/api-schema/*` to `/v1/api-schema/*`
- Update admin permissions and post-login redirects accordingly

Fixes the 404 error when accessing `/v1/api-docs` — Swagger UI was incorrectly configured outside the `/v1` namespace, causing path confusion.

## Test Plan
- [x] Local dev: verify `/v1/api-docs` loads Swagger UI after login
- [x] Verify redirect from `/v1/` goes to `/v1/api-docs`
- [x] Admin auth required for `/v1/api-docs` access

🤖 Generated with [Claude Code](https://claude.com/claude-code)