### PR TITLE
🐛 fix(statistics): paginate all Notion pages & add resilient fallback

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/TrackingService.java
+++ b/src/main/java/com/dime/api/feature/converter/TrackingService.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 public class TrackingService {
 
     private static final int MAX_ERROR_MESSAGE_LENGTH = 2000;
+    private static final int NOTION_QUERY_PAGE_SIZE = 100;
 
     @Inject
     @RestClient
@@ -140,8 +141,8 @@ public class TrackingService {
         }
 
         try {
-            ObjectNode filter = objectMapper.createObjectNode();
-            ArrayNode and = filter.putObject("filter").putArray("and");
+            ObjectNode baseQuery = objectMapper.createObjectNode();
+            ArrayNode and = baseQuery.putObject("filter").putArray("and");
 
             ObjectNode actionFilter = and.addObject();
             actionFilter.put("property", "Action");
@@ -151,25 +152,37 @@ public class TrackingService {
             statusFilter.put("property", "Status");
             statusFilter.putObject("select").put("equals", "Success");
 
-            JsonNode response = notionClient.queryDatabase(BearerTokenUtil.ensureBearer(notionToken.get()), notionVersion,
-                    trackingDbId.get(), filter);
-
             int totalFileCount = 0;
             int totalEventCount = 0;
+            boolean hasMore;
+            String nextCursor = null;
 
-            if (response.has("results")) {
-                for (JsonNode page : response.get("results")) {
-                    JsonNode props = page.get("properties");
-                    if (props != null) {
-                        if (props.has("File Count")) {
-                            totalFileCount += props.get("File Count").get("number").asInt(0);
-                        }
-                        if (props.has("Event Count")) {
-                            totalEventCount += props.get("Event Count").get("number").asInt(0);
+            do {
+                ObjectNode query = baseQuery.deepCopy();
+                query.put("page_size", NOTION_QUERY_PAGE_SIZE);
+                if (nextCursor != null && !nextCursor.isBlank()) {
+                    query.put("start_cursor", nextCursor);
+                }
+
+                JsonNode response = notionClient.queryDatabase(BearerTokenUtil.ensureBearer(notionToken.get()), notionVersion,
+                        trackingDbId.get(), query);
+
+                if (response.has("results") && response.get("results").isArray()) {
+                    for (JsonNode page : response.get("results")) {
+                        JsonNode props = page.get("properties");
+                        if (props != null) {
+                            totalFileCount += extractNumberProperty(props, "File Count");
+                            totalEventCount += extractNumberProperty(props, "Event Count");
                         }
                     }
                 }
-            }
+
+                hasMore = response.path("has_more").asBoolean(false);
+                JsonNode nextCursorNode = response.get("next_cursor");
+                nextCursor = nextCursorNode != null && !nextCursorNode.isNull()
+                        ? nextCursorNode.asText()
+                        : null;
+            } while (hasMore && nextCursor != null && !nextCursor.isBlank());
 
             log.info("Fetched statistics from Notion: fileCount={}, eventCount={}", totalFileCount, totalEventCount);
             Statistics stats = new Statistics(totalFileCount, totalEventCount);
@@ -178,8 +191,31 @@ public class TrackingService {
 
         } catch (Exception e) {
             log.error("Failed to fetch statistics from Notion", e);
+            Statistics fallback = statisticsCache != null ? statisticsCache.getIfPresent("default") : null;
+            if (fallback != null) {
+                log.warn("Using cached statistics fallback after Notion fetch failure: fileCount={}, eventCount={}",
+                        fallback.fileCount(), fallback.eventCount());
+                return fallback;
+            }
+            if (firestoreCacheService != null) {
+                Optional<Statistics> firestoreFallback = firestoreCacheService.read("statistics", Statistics.class);
+                if (firestoreFallback.isPresent()) {
+                    Statistics stats = firestoreFallback.get();
+                    log.warn("Using Firestore statistics fallback after Notion fetch failure: fileCount={}, eventCount={}",
+                            stats.fileCount(), stats.eventCount());
+                    return stats;
+                }
+            }
             return new Statistics(0, 0);
         }
+    }
+
+    private int extractNumberProperty(JsonNode properties, String propertyName) {
+        if (properties == null || !properties.has(propertyName)) {
+            return 0;
+        }
+        JsonNode numberNode = properties.get(propertyName).get("number");
+        return numberNode != null && !numberNode.isNull() ? numberNode.asInt(0) : 0;
     }
 
     @Schema(description = "Global conversion statistics aggregated from Notion tracking database")

--- a/src/test/java/com/dime/api/feature/converter/TrackingServiceBehaviorUnitTest.java
+++ b/src/test/java/com/dime/api/feature/converter/TrackingServiceBehaviorUnitTest.java
@@ -1,0 +1,98 @@
+package com.dime.api.feature.converter;
+
+import com.dime.api.feature.notion.NotionClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TrackingServiceBehaviorUnitTest {
+
+    private TrackingService service;
+    private NotionClient mockNotionClient;
+
+    @BeforeEach
+    void setup() {
+        service = new TrackingService();
+        mockNotionClient = mock(NotionClient.class);
+        service.notionClient = mockNotionClient;
+        service.objectMapper = new ObjectMapper();
+        service.notionToken = Optional.of("test-token");
+        service.trackingDbId = Optional.of("test-db-id");
+        service.notionVersion = "2022-02-22";
+        service.assignedUserId = Optional.empty();
+        service.initCaches();
+    }
+
+    @Test
+    void getStatistics_whenNotionHasMultiplePages_aggregatesAllPages() {
+        ObjectNode firstPage = buildResponse(2, 3, true, "cursor-1");
+        ObjectNode secondPage = buildResponse(4, 5, false, null);
+
+        when(mockNotionClient.queryDatabase(any(), any(), any(), any()))
+                .thenReturn(firstPage)
+                .thenReturn(secondPage);
+
+        TrackingService.Statistics stats = service.getStatistics();
+        assertEquals(6, stats.fileCount());
+        assertEquals(8, stats.eventCount());
+
+        ArgumentCaptor<Object> queryCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockNotionClient, times(2)).queryDatabase(any(), any(), any(), queryCaptor.capture());
+        JsonNode firstQuery = (JsonNode) queryCaptor.getAllValues().get(0);
+        JsonNode secondQuery = (JsonNode) queryCaptor.getAllValues().get(1);
+
+        assertFalse(firstQuery.has("start_cursor"));
+        assertEquals("cursor-1", secondQuery.get("start_cursor").asText());
+    }
+
+    @Test
+    void fetchStatistics_whenNotionThrows_returnsCachedValue() throws Exception {
+        service.statisticsCache.put("default", new TrackingService.Statistics(11, 22));
+        when(mockNotionClient.queryDatabase(any(), any(), any(), any()))
+                .thenThrow(new RuntimeException("Notion unavailable"));
+
+        TrackingService.Statistics stats = invokeFetchStatistics(service);
+        assertEquals(11, stats.fileCount());
+        assertEquals(22, stats.eventCount());
+    }
+
+    private ObjectNode buildResponse(int fileCount, int eventCount, boolean hasMore, String nextCursor) {
+        ObjectNode response = service.objectMapper.createObjectNode();
+        ArrayNode results = response.putArray("results");
+
+        ObjectNode page = results.addObject();
+        ObjectNode properties = page.putObject("properties");
+        properties.putObject("File Count").put("number", fileCount);
+        properties.putObject("Event Count").put("number", eventCount);
+
+        response.put("has_more", hasMore);
+        if (nextCursor == null) {
+            response.putNull("next_cursor");
+        } else {
+            response.put("next_cursor", nextCursor);
+        }
+        return response;
+    }
+
+    private TrackingService.Statistics invokeFetchStatistics(TrackingService trackingService) throws Exception {
+        Method fetchMethod = TrackingService.class.getDeclaredMethod("fetchStatistics");
+        fetchMethod.setAccessible(true);
+        return (TrackingService.Statistics) fetchMethod.invoke(trackingService);
+    }
+}
+


### PR DESCRIPTION
## Problème
L'endpoint `GET /v1/converter/statistics` retournait des valeurs en baisse alors qu'elles devraient seulement augmenter.
### Causes identifiées
1. **Pagination Notion ignorée** — `fetchStatistics()` ne lisait que la première page retournée par l'API Notion (≤ 100 lignes). Le total agrégé était donc un *sliding window*, pas la somme globale. Quand de nouvelles lignes entrent et que d'anciennes sortent de la première page, la somme pouvait baisser.
2. **Fallback à zéro sur erreur** — toute erreur Notion (timeout, rate-limit…) faisait retourner `Statistics(0, 0)`, faisant apparaître un drop brutal à zéro dans le cache pendant jusqu'à 1h.
## Solution
- **Pagination complète** : boucle `do/while` sur `has_more` + `next_cursor` jusqu'à épuisement de tous les résultats (`page_size = 100` par appel).
- **Fallback résilient** : en cas d'erreur Notion, on utilise dans l'ordre :
  1. Le cache mémoire Caffeine (`statisticsCache.getIfPresent("default")`)
  2. Le cache Firestore (`cache/statistics`)
  3. `Statistics(0, 0)` uniquement si les deux sont vides
- **Helper `extractNumberProperty()`** : parsing centralisé et null-safe des propriétés numériques Notion.
## Tests
Ajout de `TrackingServiceBehaviorUnitTest` (JUnit 5 pur, sans contexte Quarkus) :
- ✅ Agrégation multi-pages : vérifie que 2 appels Notion sont faits et que `start_cursor` est bien transmis au 2e appel
- ✅ Fallback cache : vérifie que la dernière valeur connue est retournée sur erreur Notion