### PR TITLE
🚑 fix(firestore): harden endpoints against tracing linkage errors

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,6 +35,8 @@ steps:
       - '$_REGION'
       - '--platform'
       - 'managed'
+      - '--update-env-vars'
+      - 'FIRESTORE_ENABLE_TRACING=false'
 
 images:
   - 'gcr.io/$PROJECT_ID/$_SERVICE_NAME:$SHORT_SHA'

--- a/src/main/java/com/dime/api/feature/converter/QuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaService.java
@@ -4,6 +4,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.*;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -51,7 +52,7 @@ public class QuotaService {
     }
 
     @Inject
-    Firestore firestore;
+    Instance<Firestore> firestoreInstance;
 
     @Inject
     NotionQuotaService notionQuotaService;
@@ -72,6 +73,10 @@ public class QuotaService {
                 .toList();
     }
 
+    Firestore firestore() {
+        return firestoreInstance.get();
+    }
+
     public void updateQuotaLimit(PlanType plan, long newLimit) {
         EnumMap<PlanType, Long> mutable = new EnumMap<>(PlanType.class);
         mutable.putAll(quotaLimits);
@@ -82,7 +87,7 @@ public class QuotaService {
 
     public QuotaCheckResult checkQuota(@NonNull String userId) {
         try {
-            DocumentSnapshot document = firestore.collection(COLLECTION_NAME).document(userId).get().get();
+            DocumentSnapshot document = firestore().collection(COLLECTION_NAME).document(userId).get().get();
 
             if (!document.exists()) {
                 UserQuota newUser = createUser(userId);
@@ -107,8 +112,8 @@ public class QuotaService {
 
             return new QuotaCheckResult(allowed, remaining, limit, userQuota.getPlanType());
 
-        } catch (Exception e) {
-            log.error("Error checking quota for user {}", userId, e);
+        } catch (Throwable t) {
+            log.error("Error checking quota for user {}", userId, t);
             // Default allow on error to not block users
             return new QuotaCheckResult(true, -1, -1, DEFAULT_PLAN);
         }
@@ -116,9 +121,9 @@ public class QuotaService {
 
     public void incrementUsage(@NonNull String userId) {
         try {
-            DocumentReference docRef = firestore.collection(COLLECTION_NAME).document(userId);
+            DocumentReference docRef = firestore().collection(COLLECTION_NAME).document(userId);
 
-            firestore.runTransaction(transaction -> {
+            firestore().runTransaction(transaction -> {
                 DocumentSnapshot snapshot = transaction.get(docRef).get();
 
                 if (!snapshot.exists()) {
@@ -145,18 +150,18 @@ public class QuotaService {
                                 quota.periodStart.toDate().toInstant());
                     }
                 }
-            } catch (Exception e) {
-                log.warn("Failed to sync to Notion for user {} (non-blocking)", userId, e);
+            } catch (Throwable t) {
+                log.warn("Failed to sync to Notion for user {} (non-blocking)", userId, t);
             }
 
-        } catch (Exception e) {
-            log.error("Error incrementing usage for user {}", userId, e);
+        } catch (Throwable t) {
+            log.error("Error incrementing usage for user {}", userId, t);
         }
     }
 
     public UserQuota getQuotaStatus(@NonNull String userId) {
         try {
-            DocumentSnapshot document = firestore.collection(COLLECTION_NAME).document(userId).get().get();
+            DocumentSnapshot document = firestore().collection(COLLECTION_NAME).document(userId).get().get();
             if (document.exists()) {
                 UserQuota userQuota = document.toObject(UserQuota.class);
                 if (userQuota != null && isNewMonth(userQuota.periodStart)) {
@@ -164,8 +169,8 @@ public class QuotaService {
                 }
                 return userQuota;
             }
-        } catch (Exception e) {
-            log.error("Error fetching quota status for {}", userId, e);
+        } catch (Throwable t) {
+            log.error("Error fetching quota status for {}", userId, t);
         }
         return null;
     }
@@ -179,7 +184,7 @@ public class QuotaService {
                 now,
                 now,
                 now);
-        firestore.collection(COLLECTION_NAME).document(userId).set(newUser).get();
+        firestore().collection(COLLECTION_NAME).document(userId).set(newUser).get();
         log.info("Created new user {}", userId);
         return newUser;
     }
@@ -198,7 +203,7 @@ public class QuotaService {
 
     private void resetQuota(@NonNull String userId) {
         Timestamp now = Timestamp.now();
-        firestore.collection(COLLECTION_NAME).document(userId).update(
+        firestore().collection(COLLECTION_NAME).document(userId).update(
                 "quotaUsed", 0,
                 "periodStart", now,
                 "updatedAt", now);
@@ -217,12 +222,12 @@ public class QuotaService {
 
     public List<UserQuotaWrapper> findAll() {
         try {
-            return firestore.collection(COLLECTION_NAME).get().get().getDocuments()
+            return firestore().collection(COLLECTION_NAME).get().get().getDocuments()
                     .stream()
                     .map(doc -> new UserQuotaWrapper(doc.getId(), doc.toObject(UserQuota.class)))
                     .collect(Collectors.toList());
-        } catch (Exception e) {
-            log.error("Error fetching all user quotas", e);
+        } catch (Throwable t) {
+            log.error("Error fetching all user quotas", t);
             return List.of();
         }
     }
@@ -230,7 +235,7 @@ public class QuotaService {
     public void updateQuota(@NonNull String userId, UserQuota quota) {
         try {
             quota.updatedAt = Timestamp.now();
-            firestore.collection(COLLECTION_NAME).document(userId).set(quota, SetOptions.merge()).get();
+            firestore().collection(COLLECTION_NAME).document(userId).set(quota, SetOptions.merge()).get();
             log.info("Updated quota for user {}", userId);
 
             // Sync to Notion after update
@@ -240,12 +245,12 @@ public class QuotaService {
                         quota.quotaUsed,
                         quota.getPlanType(),
                         quota.periodStart != null ? quota.periodStart.toDate().toInstant() : Instant.now());
-            } catch (Exception e) {
-                log.warn("Failed to sync to Notion for user {} after update (non-blocking)", userId, e);
+            } catch (Throwable t) {
+                log.warn("Failed to sync to Notion for user {} after update (non-blocking)", userId, t);
             }
 
-        } catch (Exception e) {
-            log.error("Error updating quota for user {}", userId, e);
+        } catch (Throwable t) {
+            log.error("Error updating quota for user {}", userId, t);
         }
     }
 
@@ -258,8 +263,8 @@ public class QuotaService {
             long newLimit = quotaLimits.getOrDefault(plan, quotaLimitFree);
             Timestamp now = Timestamp.now();
 
-            DocumentReference docRef = firestore.collection(COLLECTION_NAME).document(userId);
-            firestore.runTransaction(transaction -> {
+            DocumentReference docRef = firestore().collection(COLLECTION_NAME).document(userId);
+            firestore().runTransaction(transaction -> {
                 DocumentSnapshot snapshot = transaction.get(docRef).get();
                 if (!snapshot.exists()) {
                     // Create user if not exists (e.g., paid before first free use)
@@ -287,29 +292,29 @@ public class QuotaService {
                                         : java.time.Instant.now());
                     }
                 }
-            } catch (Exception e) {
-                log.warn("Failed to sync plan update to Notion for user {} (non-blocking)", userId, e);
+            } catch (Throwable t) {
+                log.warn("Failed to sync plan update to Notion for user {} (non-blocking)", userId, t);
             }
 
-        } catch (Exception e) {
-            log.error("Error updating plan for user {}", userId, e);
+        } catch (Throwable t) {
+            log.error("Error updating plan for user {}", userId, t);
         }
     }
 
     public void deleteQuota(@NonNull String userId) {
         try {
-            firestore.collection(COLLECTION_NAME).document(userId).delete().get();
+            firestore().collection(COLLECTION_NAME).document(userId).delete().get();
             log.info("Deleted quota for user {}", userId);
 
             // Delete from Notion after deletion
             try {
                 notionQuotaService.deleteFromNotion(userId);
-            } catch (Exception e) {
-                log.warn("Failed to delete from Notion for user {} (non-blocking)", userId, e);
+            } catch (Throwable t) {
+                log.warn("Failed to delete from Notion for user {} (non-blocking)", userId, t);
             }
 
-        } catch (Exception e) {
-            log.error("Error deleting quota for user {}", userId, e);
+        } catch (Throwable t) {
+            log.error("Error deleting quota for user {}", userId, t);
         }
     }
 
@@ -366,13 +371,13 @@ public class QuotaService {
 
     private void updateQuotaFromNotion(@NonNull NotionQuotaService.QuotaData data) {
         try {
-            DocumentReference docRef = firestore.collection(COLLECTION_NAME).document(data.userId());
+            DocumentReference docRef = firestore().collection(COLLECTION_NAME).document(data.userId());
             Timestamp periodStart = Timestamp.ofTimeSecondsAndNanos(data.lastReset().getEpochSecond(),
                     data.lastReset().getNano());
 
             long limit = quotaLimits.getOrDefault(data.plan(), 10L);
 
-            firestore.runTransaction(transaction -> {
+            firestore().runTransaction(transaction -> {
                 DocumentSnapshot snapshot = transaction.get(docRef).get();
                 Timestamp now = Timestamp.now();
 
@@ -398,6 +403,8 @@ public class QuotaService {
             log.info("Synced user {} from Notion to Firestore", data.userId());
         } catch (InterruptedException | ExecutionException e) {
             log.error("Error updating user {} from Notion data", data.userId(), e);
+        } catch (Throwable t) {
+            log.error("Unexpected error updating user {} from Notion data", data.userId(), t);
         }
     }
 }

--- a/src/main/java/com/dime/api/feature/shared/FirestoreCacheService.java
+++ b/src/main/java/com/dime/api/feature/shared/FirestoreCacheService.java
@@ -6,6 +6,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,37 +21,41 @@ public class FirestoreCacheService {
     private static final String COLLECTION = "cache";
 
     @Inject
-    Firestore firestore;
+    Instance<Firestore> firestoreInstance;
 
     @Inject
     ObjectMapper objectMapper;
 
+    Firestore firestore() {
+        return firestoreInstance.get();
+    }
+
     public <T> Optional<T> read(String key, Class<T> type) {
         try {
-            DocumentSnapshot doc = firestore.collection(COLLECTION).document(key).get().get();
+            DocumentSnapshot doc = firestore().collection(COLLECTION).document(key).get().get();
             if (doc.exists()) {
                 String json = doc.getString("data");
                 if (json != null) {
                     return Optional.of(objectMapper.readValue(json, type));
                 }
             }
-        } catch (Exception e) {
-            log.warn("Failed to read cache from Firestore for key: {}", key, e);
+        } catch (Throwable t) {
+            log.warn("Failed to read cache from Firestore for key: {}", key, t);
         }
         return Optional.empty();
     }
 
     public <T> Optional<T> read(String key, TypeReference<T> type) {
         try {
-            DocumentSnapshot doc = firestore.collection(COLLECTION).document(key).get().get();
+            DocumentSnapshot doc = firestore().collection(COLLECTION).document(key).get().get();
             if (doc.exists()) {
                 String json = doc.getString("data");
                 if (json != null) {
                     return Optional.of(objectMapper.readValue(json, type));
                 }
             }
-        } catch (Exception e) {
-            log.warn("Failed to read cache from Firestore for key: {}", key, e);
+        } catch (Throwable t) {
+            log.warn("Failed to read cache from Firestore for key: {}", key, t);
         }
         return Optional.empty();
     }
@@ -59,11 +64,11 @@ public class FirestoreCacheService {
         CompletableFuture.runAsync(() -> {
             try {
                 String json = objectMapper.writeValueAsString(data);
-                firestore.collection(COLLECTION).document(key)
+                firestore().collection(COLLECTION).document(key)
                         .set(Map.of("data", json, "updatedAt", Timestamp.now())).get();
                 log.debug("Written cache to Firestore for key: {}", key);
-            } catch (Exception e) {
-                log.warn("Failed to write cache to Firestore for key: {}", key, e);
+            } catch (Throwable t) {
+                log.warn("Failed to write cache to Firestore for key: {}", key, t);
             }
         });
     }

--- a/src/main/java/com/dime/api/feature/shared/health/FirestoreHealthCheck.java
+++ b/src/main/java/com/dime/api/feature/shared/health/FirestoreHealthCheck.java
@@ -2,6 +2,7 @@ package com.dime.api.feature.shared.health;
 
 import com.google.cloud.firestore.Firestore;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.health.HealthCheck;
@@ -19,10 +20,14 @@ public class FirestoreHealthCheck implements HealthCheck {
     private static final String CHECK_NAME = "firestore";
 
     @Inject
-    Firestore firestore;
+    Instance<Firestore> firestoreInstance;
 
     volatile HealthCheckResponse cachedResponse;
     volatile long lastCheckedAt = 0;
+
+    Firestore firestore() {
+        return firestoreInstance.get();
+    }
 
     @Override
     public HealthCheckResponse call() {
@@ -38,19 +43,19 @@ public class FirestoreHealthCheck implements HealthCheck {
     HealthCheckResponse doCheck() {
         long start = System.currentTimeMillis();
         try {
-            firestore.collection("users").limit(1).get().get(2, TimeUnit.SECONDS);
+            firestore().collection("users").limit(1).get().get(2, TimeUnit.SECONDS);
             long latencyMs = System.currentTimeMillis() - start;
             return HealthCheckResponse.named(CHECK_NAME)
                     .up()
                     .withData("latencyMs", latencyMs)
                     .build();
-        } catch (Exception e) {
+        } catch (Throwable t) {
             long latencyMs = System.currentTimeMillis() - start;
-            log.warn("Firestore health check failed", e);
+            log.warn("Firestore health check failed", t);
             return HealthCheckResponse.named(CHECK_NAME)
                     .down()
                     .withData("latencyMs", latencyMs)
-                    .withData("error", e.getMessage())
+                    .withData("error", String.valueOf(t.getMessage()))
                     .build();
         }
     }

--- a/src/test/java/com/dime/api/feature/converter/ConverterIntegrationTest.java
+++ b/src/test/java/com/dime/api/feature/converter/ConverterIntegrationTest.java
@@ -102,4 +102,15 @@ public class ConverterIntegrationTest {
             .then()
                 .statusCode(400); // Bad Request due to empty required parameter
     }
+
+    @Test
+    public void testPlansEndpointReturnsConfiguredPlansEvenIfFirestoreIsUnavailable() {
+        given()
+            .when().get("/v1/converter/plans")
+            .then()
+                .statusCode(200)
+                .body("size()", greaterThanOrEqualTo(4))
+                .body("plan", hasItems("FREE", "PRO", "BUSINESS", "UNLIMITED"))
+                .body("find { it.plan == 'FREE' }.limit", notNullValue());
+    }
 }

--- a/src/test/java/com/dime/api/feature/converter/QuotaServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/QuotaServiceTest.java
@@ -1,6 +1,7 @@
 package com.dime.api.feature.converter;
 
 import com.google.cloud.firestore.Firestore;
+import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,7 @@ class QuotaServiceTest {
 
     QuotaService quotaService;
     Firestore firestoreMock;
+    Instance<Firestore> firestoreInstanceMock;
     NotionQuotaService notionQuotaServiceMock;
 
     @BeforeEach
@@ -23,8 +25,10 @@ class QuotaServiceTest {
         quotaService.quotaLimitUnlimited = 1000000;
         quotaService.init();
         firestoreMock = mock(Firestore.class);
+        firestoreInstanceMock = mock(Instance.class);
+        when(firestoreInstanceMock.get()).thenReturn(firestoreMock);
         notionQuotaServiceMock = mock(NotionQuotaService.class);
-        quotaService.firestore = firestoreMock;
+        quotaService.firestoreInstance = firestoreInstanceMock;
         quotaService.notionQuotaService = notionQuotaServiceMock;
     }
 
@@ -66,5 +70,24 @@ class QuotaServiceTest {
         when(firestoreMock.collection(any())).thenThrow(new RuntimeException("Firestore error"));
         UserQuota quota = new UserQuota();
         assertDoesNotThrow(() -> quotaService.updateQuota("non-existent-user-update", quota));
+    }
+
+    @Test
+    public void testGetQuotaLimits_doesNotTouchFirestore() {
+        quotaService.getQuotaLimits();
+
+        verifyNoInteractions(firestoreInstanceMock);
+    }
+
+    @Test
+    public void testCheckQuota_handlesLinkageErrorFromFirestoreBean() {
+        when(firestoreInstanceMock.get())
+                .thenThrow(new NoSuchMethodError("GrpcTelemetry.newClientInterceptor"));
+
+        assertDoesNotThrow(() -> {
+            QuotaService.QuotaCheckResult result = quotaService.checkQuota("linkage-error-user");
+            assertTrue(result.allowed());
+            assertEquals(PlanType.FREE, result.plan());
+        });
     }
 }

--- a/src/test/java/com/dime/api/feature/shared/health/FirestoreHealthCheckTest.java
+++ b/src/test/java/com/dime/api/feature/shared/health/FirestoreHealthCheckTest.java
@@ -5,6 +5,7 @@ import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.QuerySnapshot;
+import jakarta.enterprise.inject.Instance;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,11 +19,16 @@ import static org.mockito.Mockito.*;
 class FirestoreHealthCheckTest {
 
     FirestoreHealthCheck check;
+    Firestore firestoreMock;
+    Instance<Firestore> firestoreInstanceMock;
 
     @BeforeEach
     void setup() {
         check = new FirestoreHealthCheck();
-        check.firestore = mock(Firestore.class);
+        firestoreMock = mock(Firestore.class);
+        firestoreInstanceMock = mock(Instance.class);
+        when(firestoreInstanceMock.get()).thenReturn(firestoreMock);
+        check.firestoreInstance = firestoreInstanceMock;
         check.cachedResponse = null;
         check.lastCheckedAt = 0;
     }
@@ -34,10 +40,10 @@ class FirestoreHealthCheckTest {
         ApiFuture<QuerySnapshot> future = mock(ApiFuture.class);
         QuerySnapshot snapshot = mock(QuerySnapshot.class);
 
-        when(check.firestore.collection("users")).thenReturn(collection);
+        when(firestoreMock.collection("users")).thenReturn(collection);
         when(collection.limit(1)).thenReturn(query);
         when(query.get()).thenReturn(future);
-        when(future.get(500, TimeUnit.MILLISECONDS)).thenReturn(snapshot);
+        when(future.get(2, TimeUnit.SECONDS)).thenReturn(snapshot);
 
         HealthCheckResponse response = check.doCheck();
 
@@ -53,7 +59,7 @@ class FirestoreHealthCheckTest {
         Query query = mock(Query.class);
         ApiFuture<QuerySnapshot> future = mock(ApiFuture.class);
 
-        when(check.firestore.collection("users")).thenReturn(collection);
+        when(firestoreMock.collection("users")).thenReturn(collection);
         when(collection.limit(1)).thenReturn(query);
         when(query.get()).thenReturn(future);
         when(future.get(2, TimeUnit.SECONDS)).thenThrow(new RuntimeException("connection refused"));
@@ -68,7 +74,18 @@ class FirestoreHealthCheckTest {
 
     @Test
     void testDown_onFirestoreUnavailable() {
-        when(check.firestore.collection(any())).thenThrow(new RuntimeException("Firestore unavailable"));
+        when(firestoreMock.collection(any())).thenThrow(new RuntimeException("Firestore unavailable"));
+
+        HealthCheckResponse response = check.doCheck();
+
+        assertEquals(HealthCheckResponse.Status.DOWN, response.getStatus());
+        assertTrue(response.getData().isPresent());
+        assertNotNull(response.getData().get().get("error"));
+    }
+
+    @Test
+    void testDown_onLinkageErrorDuringBeanInitialization() {
+        when(firestoreInstanceMock.get()).thenThrow(new NoSuchMethodError("GrpcTelemetry.newClientInterceptor"));
 
         HealthCheckResponse response = check.doCheck();
 
@@ -84,14 +101,14 @@ class FirestoreHealthCheckTest {
         ApiFuture<QuerySnapshot> future = mock(ApiFuture.class);
         QuerySnapshot snapshot = mock(QuerySnapshot.class);
 
-        when(check.firestore.collection("users")).thenReturn(collection);
+        when(firestoreMock.collection("users")).thenReturn(collection);
         when(collection.limit(1)).thenReturn(query);
         when(query.get()).thenReturn(future);
-        when(future.get(500, TimeUnit.MILLISECONDS)).thenReturn(snapshot);
+        when(future.get(2, TimeUnit.SECONDS)).thenReturn(snapshot);
 
         check.call();
         check.call();
 
-        verify(check.firestore, times(1)).collection("users");
+        verify(firestoreMock, times(1)).collection("users");
     }
 }


### PR DESCRIPTION
## Summary
- make Firestore access lazy so non-Firestore endpoints like `/converter/plans` do not fail during bean creation
- catch Firestore linkage errors in quota, cache and health code paths
- persist the production workaround in Cloud Run deploy config with `FIRESTORE_ENABLE_TRACING=false`
- add regression tests for `/converter/plans`, quota resilience and Firestore health behavior

## Validation
- `mvn test -Dtest="QuotaServiceTest,FirestoreHealthCheckTest,ConverterIntegrationTest"`
- `mvn -DskipTests package -q`
- verified production endpoints after rollout:
  - `GET /v1/converter/plans` -> 200
  - `GET /v1/converter/quota-status?userId=diagnostic-user` -> 404
  - `GET /v1/converter/statistics` -> 200

## Context
This mitigates the runtime `NoSuchMethodError` between Firestore and OpenTelemetry by preventing eager Firestore bean initialization from breaking unrelated endpoints while also keeping the production tracing workaround in deployment config.