### PR TITLE
🔧 fix(deps): align Firestore gRPC telemetry with Quarkus OTel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,8 @@
 
     <!-- Dependency Versions -->
     <quarkus-google-cloud-firestore.version>2.21.0</quarkus-google-cloud-firestore.version>
+    <opentelemetry-grpc.version>2.1.0-alpha</opentelemetry-grpc.version>
+    <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
     <dotenv-java.version>3.2.0</dotenv-java.version>
     <lombok.version>1.18.46</lombok.version>
   </properties>
@@ -168,6 +170,16 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.instrumentation</groupId>
+      <artifactId>opentelemetry-grpc-1.6</artifactId>
+      <version>${opentelemetry-grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.semconv</groupId>
+      <artifactId>opentelemetry-semconv</artifactId>
+      <version>${opentelemetry-semconv.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/test/java/com/dime/api/feature/shared/FirestoreCompatibilityTest.java
+++ b/src/test/java/com/dime/api/feature/shared/FirestoreCompatibilityTest.java
@@ -1,0 +1,31 @@
+package com.dime.api.feature.shared;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class FirestoreCompatibilityTest {
+
+    @Test
+    void firestoreServiceCreation_doesNotThrowTelemetryLinkageError() {
+        assertDoesNotThrow(() -> {
+            try (Firestore firestore = FirestoreOptions.newBuilder()
+                    .setProjectId("test-project")
+                    .setCredentials(GoogleCredentials.create(
+                            new AccessToken("test-token", new Date(Long.MAX_VALUE))))
+                    .build()
+                    .getService()) {
+                assertNotNull(firestore);
+            }
+        });
+    }
+}
+
+


### PR DESCRIPTION
## Summary
- pin `opentelemetry-grpc-1.6` to the API shape expected by `google-cloud-firestore`
- add the matching `opentelemetry-semconv` jar required by that instrumentation module
- add a direct Firestore compatibility regression test that exercises Firestore service creation

## Why
Quarkus 3.35.2 brings a newer OpenTelemetry gRPC instrumentation artifact where `GrpcTelemetry.newClientInterceptor()` no longer exists. `google-cloud-firestore` still calls that older API, which caused runtime `NoSuchMethodError` during Firestore client creation.

## Validation
- `mvn dependency:tree -Dincludes="io.opentelemetry.instrumentation:opentelemetry-grpc-1.6,io.opentelemetry.semconv:opentelemetry-semconv"`
- `mvn test -Dtest="FirestoreCompatibilityTest,ConverterIntegrationTest,FirestoreHealthCheckTest"`
- `mvn -DskipTests package -q`

## Notes
This is the root-cause dependency fix. The separate mitigation PR keeps the Cloud Run workaround and resilience improvements in place.