### PR TITLE
fix(notion): paginate fetchAllFromNotion to avoid stale sync data

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/NotionQuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/NotionQuotaService.java
@@ -103,29 +103,38 @@ public class NotionQuotaService {
             return List.of();
 
         List<QuotaData> results = new ArrayList<>();
+        String cursor = null;
         try {
-            ObjectNode query = objectMapper.createObjectNode();
-            JsonNode response = notionClient.queryDatabase(BearerTokenUtil.ensureBearer(token), version, quotaDbId.get(), query);
+            do {
+                ObjectNode query = objectMapper.createObjectNode();
+                if (cursor != null) {
+                    query.put("start_cursor", cursor);
+                }
+                JsonNode response = notionClient.queryDatabase(BearerTokenUtil.ensureBearer(token), version, quotaDbId.get(), query);
 
-            if (response.has("results") && response.get("results").isArray()) {
-                for (JsonNode page : response.get("results")) {
-                    JsonNode props = page.get("properties");
-                    if (props != null) {
-                        String userId = getTitleContent(props.get("User ID"));
-                        long usageCount = getNumberContent(props.get("Usage Count"));
-                        String planStr = getSelectContent(props.get("Plan"));
-                        String lastResetStr = getDateContent(props.get("Last Reset"));
+                if (response.has("results") && response.get("results").isArray()) {
+                    for (JsonNode page : response.get("results")) {
+                        JsonNode props = page.get("properties");
+                        if (props != null) {
+                            String userId = getTitleContent(props.get("User ID"));
+                            long usageCount = getNumberContent(props.get("Usage Count"));
+                            String planStr = getSelectContent(props.get("Plan"));
+                            String lastResetStr = getDateContent(props.get("Last Reset"));
 
-                        if (userId != null && !userId.isEmpty()) {
-                            results.add(new QuotaData(
-                                    userId,
-                                    usageCount,
-                                    lastResetStr != null ? Instant.parse(lastResetStr) : Instant.now(),
-                                    PlanType.fromString(planStr)));
+                            if (userId != null && !userId.isEmpty()) {
+                                results.add(new QuotaData(
+                                        userId,
+                                        usageCount,
+                                        lastResetStr != null ? Instant.parse(lastResetStr) : Instant.now(),
+                                        PlanType.fromString(planStr)));
+                            }
                         }
                     }
                 }
-            }
+
+                boolean hasMore = response.path("has_more").asBoolean(false);
+                cursor = hasMore ? response.path("next_cursor").asText(null) : null;
+            } while (cursor != null);
         } catch (Exception e) {
             log.warn("Failed to fetch all from Notion (non-blocking)", e);
         }

--- a/src/test/java/com/dime/api/feature/converter/NotionQuotaServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/NotionQuotaServiceTest.java
@@ -1,18 +1,21 @@
 package com.dime.api.feature.converter;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.dime.api.feature.notion.NotionClient;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @QuarkusTest
@@ -57,6 +60,47 @@ public class NotionQuotaServiceTest {
         ObjectNode node = objectMapper.createObjectNode();
         notionQuotaService.addTitleProperty(node, "User ID", "user1");
         assertTrue(node.has("User ID"));
+    }
+
+    @Test
+    public void testFetchAllFromNotionPaginates() {
+        ObjectNode page1 = buildPageResponse("user1", 3, "FREE", "2026-01-01T00:00:00Z", true, "cursor-abc");
+        ObjectNode page2 = buildPageResponse("user2", 7, "PRO", "2026-02-01T00:00:00Z", false, null);
+
+        when(notionClient.queryDatabase(any(), any(), any(), any()))
+                .thenAnswer(inv -> {
+                    JsonNode body = objectMapper.convertValue(inv.getArgument(3), JsonNode.class);
+                    if (body.has("start_cursor") && "cursor-abc".equals(body.get("start_cursor").asText())) {
+                        return page2;
+                    }
+                    return page1;
+                });
+
+        List<NotionQuotaService.QuotaData> results = notionQuotaService.fetchAllFromNotion();
+
+        assertEquals(2, results.size());
+        assertEquals("user1", results.get(0).userId());
+        assertEquals("user2", results.get(1).userId());
+        verify(notionClient, times(2)).queryDatabase(any(), any(), any(), any());
+    }
+
+    private ObjectNode buildPageResponse(String userId, long usageCount, String plan, String lastReset,
+            boolean hasMore, String nextCursor) {
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode results = response.putArray("results");
+        ObjectNode page = results.addObject();
+        ObjectNode props = page.putObject("properties");
+
+        notionQuotaService.addTitleProperty(props, "User ID", userId);
+        props.putObject("Usage Count").put("number", usageCount);
+        props.putObject("Plan").putObject("select").put("name", plan);
+        props.putObject("Last Reset").putObject("date").put("start", lastReset);
+
+        response.put("has_more", hasMore);
+        if (nextCursor != null) {
+            response.put("next_cursor", nextCursor);
+        }
+        return response;
     }
 
 }


### PR DESCRIPTION
## Summary

- `fetchAllFromNotion()` only fetched the first page of Notion results (max 100 records), silently skipping any users on subsequent pages
- Added a `do/while` pagination loop using `has_more` and `next_cursor` from the Notion API response
- Added `testFetchAllFromNotionPaginates` to verify multi-page fetching works correctly

## Test plan

- [ ] All 5 `NotionQuotaServiceTest` tests pass (verified locally)
- [ ] `POST /users/sync-firebase` now returns all users from Notion, not just the first 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)