### PR TITLE
feat(quota): store email on user records and normalize userId to Firebase UID

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/ConverterResource.java
+++ b/src/main/java/com/dime/api/feature/converter/ConverterResource.java
@@ -67,7 +67,8 @@ public class ConverterResource {
             @Context ContainerRequestContext requestContext) {
         long startTime = System.currentTimeMillis();
         String verifiedUid = (String) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_UID);
-        String userId = verifiedUid != null ? verifiedUid : (request.userId != null ? request.userId : "anonymous");
+        String email = (String) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_EMAIL);
+        String userId = verifiedUid != null ? verifiedUid : "anonymous";
         String domain = getDomain(headers);
         int fileCount = request.files != null ? request.files.size() : 0;
 
@@ -92,7 +93,7 @@ public class ConverterResource {
         }
 
         // Check Quota
-        QuotaService.QuotaCheckResult quota = quotaService.checkQuota(userId);
+        QuotaService.QuotaCheckResult quota = quotaService.checkQuota(userId, email);
         if (!quota.allowed()) {
             trackingService.logQuotaExceeded(userId, (int) (quota.limit() - quota.remaining()), (int) quota.limit(),
                     quota.plan().toString(), domain);
@@ -125,7 +126,7 @@ public class ConverterResource {
 
             // Success
             int eventCount = countEvents(icsContent);
-            quotaService.incrementUsage(userId);
+            quotaService.incrementUsage(userId, email);
             trackingService.logConversion(userId, fileCount, domain, eventCount,
                     System.currentTimeMillis() - startTime);
 

--- a/src/main/java/com/dime/api/feature/converter/QuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaService.java
@@ -85,12 +85,12 @@ public class QuotaService {
         log.info("Updated quota limit for {}: {}", plan, newLimit);
     }
 
-    public QuotaCheckResult checkQuota(@NonNull String userId) {
+    public QuotaCheckResult checkQuota(@NonNull String userId, String email) {
         try {
             DocumentSnapshot document = firestore().collection(COLLECTION_NAME).document(userId).get().get();
 
             if (!document.exists()) {
-                UserQuota newUser = createUser(userId);
+                UserQuota newUser = createUser(userId, email);
                 return new QuotaCheckResult(true, newUser.quotaLimit, newUser.quotaLimit, newUser.getPlanType());
             }
 
@@ -119,7 +119,7 @@ public class QuotaService {
         }
     }
 
-    public void incrementUsage(@NonNull String userId) {
+    public void incrementUsage(@NonNull String userId, String email) {
         try {
             DocumentReference docRef = firestore().collection(COLLECTION_NAME).document(userId);
 
@@ -127,10 +127,13 @@ public class QuotaService {
                 DocumentSnapshot snapshot = transaction.get(docRef).get();
 
                 if (!snapshot.exists()) {
-                    createUserInTransaction(transaction, docRef);
+                    createUserInTransaction(transaction, docRef, email);
                 } else {
                     transaction.update(docRef, "quotaUsed", FieldValue.increment(1));
                     transaction.update(docRef, "updatedAt", Timestamp.now());
+                    if (email != null && snapshot.getString("email") == null) {
+                        transaction.update(docRef, "email", email);
+                    }
                 }
                 return null;
             }).get();
@@ -175,7 +178,7 @@ public class QuotaService {
         return null;
     }
 
-    private UserQuota createUser(@NonNull String userId) throws ExecutionException, InterruptedException {
+    private UserQuota createUser(@NonNull String userId, String email) throws ExecutionException, InterruptedException {
         Timestamp now = Timestamp.now();
         UserQuota newUser = new UserQuota(
                 DEFAULT_PLAN,
@@ -184,12 +187,14 @@ public class QuotaService {
                 now,
                 now,
                 now);
+        newUser.email = email;
         firestore().collection(COLLECTION_NAME).document(userId).set(newUser).get();
         log.info("Created new user {}", userId);
         return newUser;
     }
 
-    private void createUserInTransaction(@NonNull Transaction transaction, @NonNull DocumentReference docRef) {
+    private void createUserInTransaction(@NonNull Transaction transaction, @NonNull DocumentReference docRef,
+            String email) {
         Timestamp now = Timestamp.now();
         UserQuota newUser = new UserQuota(
                 DEFAULT_PLAN,
@@ -198,7 +203,24 @@ public class QuotaService {
                 now,
                 now,
                 now);
+        newUser.email = email;
         transaction.set(docRef, newUser);
+    }
+
+    public UserQuotaWrapper findByEmail(@NonNull String email) {
+        try {
+            QuerySnapshot result = firestore().collection(COLLECTION_NAME)
+                    .whereEqualTo("email", email)
+                    .limit(1)
+                    .get().get();
+            if (!result.isEmpty()) {
+                DocumentSnapshot doc = result.getDocuments().get(0);
+                return new UserQuotaWrapper(doc.getId(), doc.toObject(UserQuota.class));
+            }
+        } catch (Throwable t) {
+            log.error("Error searching user by email {}", email, t);
+        }
+        return null;
     }
 
     private void resetQuota(@NonNull String userId) {

--- a/src/main/java/com/dime/api/feature/converter/UserQuota.java
+++ b/src/main/java/com/dime/api/feature/converter/UserQuota.java
@@ -20,6 +20,8 @@ public class UserQuota {
     public Timestamp createdAt;
     public Timestamp updatedAt;
 
+    public String email;
+
     // Stripe subscription tracking
     public String stripeCustomerId;
     public String stripeSubscriptionId;

--- a/src/main/java/com/dime/api/feature/converter/UserQuotaResource.java
+++ b/src/main/java/com/dime/api/feature/converter/UserQuotaResource.java
@@ -28,6 +28,20 @@ public class UserQuotaResource {
     QuotaService quotaService;
 
     @GET
+    @Path("/search")
+    @Operation(summary = "Search user by email", description = "Finds a user quota record by email address")
+    @APIResponse(responseCode = "200", description = "User found", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = QuotaService.UserQuotaWrapper.class)))
+    @APIResponse(responseCode = "404", description = "User not found")
+    public Response searchByEmail(@QueryParam("email") @NotNull String email) {
+        log.info("GET /users/search?email={} called", email);
+        QuotaService.UserQuotaWrapper result = quotaService.findByEmail(email);
+        if (result == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(result).build();
+    }
+
+    @GET
     @Operation(summary = "List all user quotas", description = "Retrieves a list of all users and their current quota status")
     @APIResponse(responseCode = "200", description = "List of user quotas", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = QuotaService.UserQuotaWrapper.class, type = SchemaType.ARRAY)))
     public List<QuotaService.UserQuotaWrapper> getAllQuotas() {

--- a/src/test/java/com/dime/api/feature/converter/QuotaServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/QuotaServiceTest.java
@@ -35,7 +35,7 @@ class QuotaServiceTest {
     @Test
     public void testIncrementUsageHandlesException() {
         when(firestoreMock.collection(any())).thenThrow(new RuntimeException("Firestore error"));
-        assertDoesNotThrow(() -> quotaService.incrementUsage("user1"));
+        assertDoesNotThrow(() -> quotaService.incrementUsage("user1", null));
     }
 
     @Test
@@ -48,7 +48,7 @@ class QuotaServiceTest {
     public void testCheckQuota_neverThrows_andDefaultsToAllow() {
         when(firestoreMock.collection(any())).thenThrow(new RuntimeException("Firestore error"));
         assertDoesNotThrow(() -> {
-            QuotaService.QuotaCheckResult result = quotaService.checkQuota("resilience-test-user");
+            QuotaService.QuotaCheckResult result = quotaService.checkQuota("resilience-test-user", null);
             assertTrue(result.allowed());
         });
     }
@@ -85,7 +85,7 @@ class QuotaServiceTest {
                 .thenThrow(new NoSuchMethodError("GrpcTelemetry.newClientInterceptor"));
 
         assertDoesNotThrow(() -> {
-            QuotaService.QuotaCheckResult result = quotaService.checkQuota("linkage-error-user");
+            QuotaService.QuotaCheckResult result = quotaService.checkQuota("linkage-error-user", null);
             assertTrue(result.allowed());
             assertEquals(PlanType.FREE, result.plan());
         });


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `request.userId` (free-text body field) was used as a fallback when no Firebase token was present, letting the same real user appear under two Firestore document keys — their Firebase UID and whatever string the client sent (often an email). This made quota data inconsistent and made Notion sync misleading.
- **`email` field added to `UserQuota`**: populated from the verified Firebase token on first write, backfilled silently on subsequent conversions if the field was missing.
- **`request.userId` fallback removed**: userId is now always the Firebase UID, or `"anonymous"` — never a raw client-supplied string.
- **`GET /users/search?email=`** added to `UserQuotaResource`: queries Firestore by the `email` field so admin lookups by email remain possible without relying on document ID.

## Test plan

- [ ] 111 existing tests pass (excluding `RootResourceTest` which was already failing on `main`)
- [ ] New users created via Firebase auth have their email stored in Firestore
- [ ] `GET /v1/users/search?email=user@example.com` returns the correct record
- [ ] Unauthenticated calls land under `"anonymous"` instead of a client-supplied string

🤖 Generated with [Claude Code](https://claude.com/claude-code)