### PR TITLE
feat(notion): sync email field to/from Notion quota database

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/NotionQuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/NotionQuotaService.java
@@ -66,7 +66,7 @@ public class NotionQuotaService {
         }
     }
 
-    public void syncToNotion(String userId, long quotaUsed, PlanType plan, Instant periodStart) {
+    public void syncToNotion(String userId, long quotaUsed, PlanType plan, Instant periodStart, String email) {
         if (!isEnabled())
             return;
 
@@ -78,6 +78,9 @@ public class NotionQuotaService {
             addNumberProperty(properties, "Usage Count", quotaUsed);
             addDateProperty(properties, "Last Reset", periodStart.toString());
             addSelectProperty(properties, "Plan", plan.name());
+            if (email != null) {
+                addRichTextProperty(properties, "Email", email);
+            }
 
             String authToken = BearerTokenUtil.ensureBearer(token);
 
@@ -121,12 +124,15 @@ public class NotionQuotaService {
                             String planStr = getSelectContent(props.get("Plan"));
                             String lastResetStr = getDateContent(props.get("Last Reset"));
 
+                            String email = getRichTextContent(props.get("Email"));
+
                             if (userId != null && !userId.isEmpty()) {
                                 results.add(new QuotaData(
                                         userId,
                                         usageCount,
                                         lastResetStr != null ? Instant.parse(lastResetStr) : Instant.now(),
-                                        PlanType.fromString(planStr)));
+                                        PlanType.fromString(planStr),
+                                        email));
                             }
                         }
                     }
@@ -205,6 +211,20 @@ public class NotionQuotaService {
         properties.putObject(name).putObject("select").put("name", option);
     }
 
-    public record QuotaData(String userId, long usageCount, Instant lastReset, PlanType plan) {
+    void addRichTextProperty(ObjectNode properties, String name, String content) {
+        ObjectNode wrapper = properties.putObject(name);
+        ArrayNode richTextArray = wrapper.putArray("rich_text");
+        richTextArray.addObject().putObject("text").put("content", content);
+    }
+
+    String getRichTextContent(JsonNode property) {
+        if (property != null && property.has("rich_text") && property.get("rich_text").isArray()
+                && property.get("rich_text").size() > 0) {
+            return property.get("rich_text").get(0).get("text").get("content").asText();
+        }
+        return null;
+    }
+
+    public record QuotaData(String userId, long usageCount, Instant lastReset, PlanType plan, String email) {
     }
 }

--- a/src/main/java/com/dime/api/feature/converter/QuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaService.java
@@ -150,7 +150,8 @@ public class QuotaService {
                                 userId,
                                 quota.quotaUsed,
                                 quota.getPlanType(),
-                                quota.periodStart.toDate().toInstant());
+                                quota.periodStart.toDate().toInstant(),
+                                quota.email);
                     }
                 }
             } catch (Throwable t) {
@@ -266,7 +267,8 @@ public class QuotaService {
                         userId,
                         quota.quotaUsed,
                         quota.getPlanType(),
-                        quota.periodStart != null ? quota.periodStart.toDate().toInstant() : Instant.now());
+                        quota.periodStart != null ? quota.periodStart.toDate().toInstant() : Instant.now(),
+                        quota.email);
             } catch (Throwable t) {
                 log.warn("Failed to sync to Notion for user {} after update (non-blocking)", userId, t);
             }
@@ -311,7 +313,8 @@ public class QuotaService {
                     if (quota != null) {
                         notionQuotaService.syncToNotion(userId, quota.quotaUsed, plan,
                                 quota.periodStart != null ? quota.periodStart.toDate().toInstant()
-                                        : java.time.Instant.now());
+                                        : java.time.Instant.now(),
+                                quota.email);
                     }
                 }
             } catch (Throwable t) {
@@ -360,7 +363,8 @@ public class QuotaService {
                             wrapper.quota().quotaUsed,
                             wrapper.quota().getPlanType(),
                             wrapper.quota().periodStart != null ? wrapper.quota().periodStart.toDate().toInstant()
-                                    : Instant.now());
+                                    : Instant.now(),
+                            wrapper.quota().email);
                 } catch (Exception e) {
                     log.warn("Failed to sync user {} to Notion during sync", wrapper.userId(), e);
                 }
@@ -411,14 +415,19 @@ public class QuotaService {
                             periodStart,
                             now,
                             now);
+                    newUser.email = data.email();
                     transaction.set(docRef, newUser);
                 } else {
-                    transaction.update(docRef,
-                            "plan", data.plan().name(),
-                            "quotaUsed", data.usageCount(),
-                            "quotaLimit", limit,
-                            "periodStart", periodStart,
-                            "updatedAt", now);
+                    java.util.Map<String, Object> updates = new java.util.HashMap<>();
+                    updates.put("plan", data.plan().name());
+                    updates.put("quotaUsed", data.usageCount());
+                    updates.put("quotaLimit", limit);
+                    updates.put("periodStart", periodStart);
+                    updates.put("updatedAt", now);
+                    if (data.email() != null) {
+                        updates.put("email", data.email());
+                    }
+                    transaction.update(docRef, updates);
                 }
                 return null;
             }).get();

--- a/src/test/java/com/dime/api/feature/converter/NotionQuotaServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/NotionQuotaServiceTest.java
@@ -40,7 +40,7 @@ public class NotionQuotaServiceTest {
     public void testSyncToNotionHandlesDisabled() {
         notionQuotaService.quotaDbId = Optional.empty();
         // Should not throw
-        assertDoesNotThrow(() -> notionQuotaService.syncToNotion("user1", 5, PlanType.FREE, Instant.now()));
+        assertDoesNotThrow(() -> notionQuotaService.syncToNotion("user1", 5, PlanType.FREE, Instant.now(), null));
     }
 
     @Test
@@ -80,12 +80,15 @@ public class NotionQuotaServiceTest {
 
         assertEquals(2, results.size());
         assertEquals("user1", results.get(0).userId());
+        assertEquals("user1@example.com", results.get(0).email());
         assertEquals("user2", results.get(1).userId());
+        assertEquals("user2@example.com", results.get(1).email());
         verify(notionClient, times(2)).queryDatabase(any(), any(), any(), any());
     }
 
     private ObjectNode buildPageResponse(String userId, long usageCount, String plan, String lastReset,
             boolean hasMore, String nextCursor) {
+        String email = userId + "@example.com";
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode results = response.putArray("results");
         ObjectNode page = results.addObject();
@@ -95,6 +98,7 @@ public class NotionQuotaServiceTest {
         props.putObject("Usage Count").put("number", usageCount);
         props.putObject("Plan").putObject("select").put("name", plan);
         props.putObject("Last Reset").putObject("date").put("start", lastReset);
+        notionQuotaService.addRichTextProperty(props, "Email", email);
 
         response.put("has_more", hasMore);
         if (nextCursor != null) {


### PR DESCRIPTION
## Summary

- Adds an **Email** column (Notion `rich_text` type) to the quota database sync
- Every `syncToNotion` call now includes the email when available; the field is skipped rather than nulled out when absent
- `fetchAllFromNotion` reads the Email column back, and `updateQuotaFromNotion` writes it to Firestore — so a sync-from-Notion also keeps email current
- `addRichTextProperty` / `getRichTextContent` helpers added to `NotionQuotaService`
- Pagination test updated to assert email is correctly round-tripped

## Notion setup required

Add an **Email** column of type **Text** to your quota Notion database. The column name must be exactly `Email`.

## Test plan

- [ ] 111 tests pass (excluding pre-existing `RootResourceTest` failure)
- [ ] After a conversion, the Notion row shows the user's email
- [ ] `POST /users/sync-notion` pushes email for all existing users
- [ ] `POST /users/sync-firebase` pulls email back into Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)