### PR TITLE
fix(quota): lower PRO plan default limit to 30 conversions/month

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -125,7 +125,7 @@ stripe.donation.cancel.url=${STRIPE_DONATION_CANCEL_URL:https://photocalia.com/p
 
 # Quota Limits per Plan
 quota.limit.free=${QUOTA_LIMIT_FREE:3}
-quota.limit.pro=${QUOTA_LIMIT_PRO:100}
+quota.limit.pro=${QUOTA_LIMIT_PRO:30}
 quota.limit.business=${QUOTA_LIMIT_BUSINESS:120}
 quota.limit.unlimited=${QUOTA_LIMIT_UNLIMITED:1000000}
 


### PR DESCRIPTION
## Summary
- Lower the default PRO plan quota limit from 100 to 30 conversions/month

## Test plan
- [ ] Verify `quota.limit.pro` defaults to `30` in `application.properties`
- [ ] Confirm existing `QUOTA_LIMIT_PRO` env var override still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)