### PR TITLE
fix(security): security hardening — GraphQL injection, credential race, health stampede, CORS, error leakage

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/GeminiService.java
+++ b/src/main/java/com/dime/api/feature/converter/GeminiService.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Optional;
@@ -146,25 +147,22 @@ public class GeminiService {
     }
 
     String getAccessToken() throws IOException {
-        if (cachedCredentials == null) {
-            synchronized (this) {
-                if (cachedCredentials == null) {
-                    if (apiKeyJson.isPresent() && !apiKeyJson.get().trim().isEmpty()) {
-                        // Use the configured service account JSON
-                        log.debug("Using configured service account credentials");
-                        ByteArrayInputStream credentialsStream = new ByteArrayInputStream(apiKeyJson.get().getBytes());
-                        cachedCredentials = ServiceAccountCredentials.fromStream(credentialsStream)
-                                .createScoped(
-                                        Collections.singleton("https://www.googleapis.com/auth/generative-language"));
-                    } else {
-                        throw new IOException("Missing Gemini API credentials: apiKeyJson is empty");
-                    }
+        synchronized (this) {
+            if (cachedCredentials == null) {
+                if (apiKeyJson.isPresent() && !apiKeyJson.get().trim().isEmpty()) {
+                    log.debug("Using configured service account credentials");
+                    ByteArrayInputStream credentialsStream = new ByteArrayInputStream(
+                            apiKeyJson.get().getBytes(StandardCharsets.UTF_8));
+                    cachedCredentials = ServiceAccountCredentials.fromStream(credentialsStream)
+                            .createScoped(
+                                    Collections.singleton("https://www.googleapis.com/auth/generative-language"));
+                } else {
+                    throw new IOException("Missing Gemini API credentials: apiKeyJson is empty");
                 }
             }
+            cachedCredentials.refreshIfExpired();
+            return cachedCredentials.getAccessToken().getTokenValue();
         }
-
-        cachedCredentials.refreshIfExpired();
-        return cachedCredentials.getAccessToken().getTokenValue();
     }
 
     String cleanIcs(String text) {

--- a/src/main/java/com/dime/api/feature/github/GitHubService.java
+++ b/src/main/java/com/dime/api/feature/github/GitHubService.java
@@ -146,6 +146,10 @@ public class GitHubService {
   private List<Map<String, Object>> fetchCommits(int months) {
     log.info("Fetching GitHub commits for: {} (months: {})", username, months);
 
+    if (username == null || !username.matches("[a-zA-Z0-9-]{1,39}")) {
+      throw new ExternalServiceException("GitHub", "Invalid GitHub username configured: " + username);
+    }
+
     String query = """
         query {
           user(login: "%s") {

--- a/src/main/java/com/dime/api/feature/notion/NotionService.java
+++ b/src/main/java/com/dime/api/feature/notion/NotionService.java
@@ -130,12 +130,10 @@ public class NotionService {
                 errorBody = "Unable to read error response";
             }
             log.error("Notion API error: {} - Status: {}", errorBody, e.getResponse().getStatus(), e);
-            throw new ExternalServiceException("Notion",
-                    "Notion API returned error (Status " + e.getResponse().getStatus() + "): " + errorBody, e);
+            throw new ExternalServiceException("Notion", "Unable to fetch CMS content. Please try again.", e);
         } catch (Exception e) {
             log.error("Failed to fetch CMS content from Notion", e);
-            throw new ExternalServiceException("Notion",
-                    "Failed to fetch CMS content from Notion: " + e.getMessage(), e);
+            throw new ExternalServiceException("Notion", "Unable to fetch CMS content. Please try again.", e);
         }
     }
 

--- a/src/main/java/com/dime/api/feature/shared/health/FirestoreHealthCheck.java
+++ b/src/main/java/com/dime/api/feature/shared/health/FirestoreHealthCheck.java
@@ -22,6 +22,7 @@ public class FirestoreHealthCheck implements HealthCheck {
     @Inject
     Instance<Firestore> firestoreInstance;
 
+    private final Object lock = new Object();
     volatile HealthCheckResponse cachedResponse;
     volatile long lastCheckedAt = 0;
 
@@ -35,9 +36,15 @@ public class FirestoreHealthCheck implements HealthCheck {
         if (cachedResponse != null && (now - lastCheckedAt) < CACHE_TTL_MS) {
             return cachedResponse;
         }
-        cachedResponse = doCheck();
-        lastCheckedAt = System.currentTimeMillis();
-        return cachedResponse;
+        synchronized (lock) {
+            now = System.currentTimeMillis();
+            if (cachedResponse != null && (now - lastCheckedAt) < CACHE_TTL_MS) {
+                return cachedResponse;
+            }
+            cachedResponse = doCheck();
+            lastCheckedAt = System.currentTimeMillis();
+            return cachedResponse;
+        }
     }
 
     HealthCheckResponse doCheck() {

--- a/src/main/java/com/dime/api/feature/shared/health/GeminiHealthCheck.java
+++ b/src/main/java/com/dime/api/feature/shared/health/GeminiHealthCheck.java
@@ -19,6 +19,7 @@ public class GeminiHealthCheck implements HealthCheck {
     @Inject
     GeminiService geminiService;
 
+    private final Object lock = new Object();
     volatile HealthCheckResponse cachedResponse;
     volatile long lastCheckedAt = 0;
 
@@ -28,9 +29,15 @@ public class GeminiHealthCheck implements HealthCheck {
         if (cachedResponse != null && (now - lastCheckedAt) < CACHE_TTL_MS) {
             return cachedResponse;
         }
-        cachedResponse = doCheck();
-        lastCheckedAt = System.currentTimeMillis();
-        return cachedResponse;
+        synchronized (lock) {
+            now = System.currentTimeMillis();
+            if (cachedResponse != null && (now - lastCheckedAt) < CACHE_TTL_MS) {
+                return cachedResponse;
+            }
+            cachedResponse = doCheck();
+            lastCheckedAt = System.currentTimeMillis();
+            return cachedResponse;
+        }
     }
 
     HealthCheckResponse doCheck() {

--- a/src/main/java/com/dime/api/feature/shared/health/GitHubHealthCheck.java
+++ b/src/main/java/com/dime/api/feature/shared/health/GitHubHealthCheck.java
@@ -27,6 +27,7 @@ public class GitHubHealthCheck implements HealthCheck {
     @ConfigProperty(name = "github.token")
     Optional<String> token;
 
+    private final Object lock = new Object();
     volatile HealthCheckResponse cachedResponse;
     volatile long lastCheckedAt = 0;
 
@@ -36,9 +37,15 @@ public class GitHubHealthCheck implements HealthCheck {
         if (cachedResponse != null && (now - lastCheckedAt) < CACHE_TTL_MS) {
             return cachedResponse;
         }
-        cachedResponse = doCheck();
-        lastCheckedAt = System.currentTimeMillis();
-        return cachedResponse;
+        synchronized (lock) {
+            now = System.currentTimeMillis();
+            if (cachedResponse != null && (now - lastCheckedAt) < CACHE_TTL_MS) {
+                return cachedResponse;
+            }
+            cachedResponse = doCheck();
+            lastCheckedAt = System.currentTimeMillis();
+            return cachedResponse;
+        }
     }
 
     HealthCheckResponse doCheck() {

--- a/src/main/java/com/dime/api/feature/shared/health/NotionHealthCheck.java
+++ b/src/main/java/com/dime/api/feature/shared/health/NotionHealthCheck.java
@@ -29,6 +29,7 @@ public class NotionHealthCheck implements HealthCheck {
     @ConfigProperty(name = "notion.version")
     String version;
 
+    private final Object lock = new Object();
     volatile HealthCheckResponse cachedResponse;
     volatile long lastCheckedAt = 0;
 
@@ -38,9 +39,15 @@ public class NotionHealthCheck implements HealthCheck {
         if (cachedResponse != null && (now - lastCheckedAt) < CACHE_TTL_MS) {
             return cachedResponse;
         }
-        cachedResponse = doCheck();
-        lastCheckedAt = System.currentTimeMillis();
-        return cachedResponse;
+        synchronized (lock) {
+            now = System.currentTimeMillis();
+            if (cachedResponse != null && (now - lastCheckedAt) < CACHE_TTL_MS) {
+                return cachedResponse;
+            }
+            cachedResponse = doCheck();
+            lastCheckedAt = System.currentTimeMillis();
+            return cachedResponse;
+        }
     }
 
     HealthCheckResponse doCheck() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -195,7 +195,7 @@ quarkus.http.cors.methods=GET,PUT,POST,DELETE,PATCH,OPTIONS
 quarkus.http.cors.headers=accept,authorization,content-type,x-requested-with
 quarkus.http.cors.exposed-headers=Content-Disposition,Content-Type
 quarkus.http.cors.access-control-max-age=24H
-%dev.quarkus.http.cors.origins=/.*/
+%dev.quarkus.http.cors.origins=http://localhost:3000,http://localhost:4200,http://localhost:8080
 
 # Cache: Managed programmatically via Caffeine LoadingCache with stale-while-revalidate
 # (refreshAfterWrite returns stale data instantly while refreshing in background)


### PR DESCRIPTION
## Summary
- Validate GitHub username against `[a-zA-Z0-9-]{1,39}` before GraphQL interpolation to prevent injection
- Fix Gemini credential refresh race: move `refreshIfExpired()` inside synchronized block + use explicit UTF-8 charset
- Fix health check cache stampede in all 4 health checks with synchronized double-checked locking
- Prevent Notion error body leakage — return generic message to client, log full error internally
- Replace CORS wildcard regex `/.*/` with explicit localhost origins in dev profile

## Test plan
- [ ] `mvn test` passes
- [ ] `GET /health` returns UP for all checks
- [ ] `GET /v1/notion/cms` error response does not expose Notion error body
- [ ] Dev mode CORS no longer accepts arbitrary origins

🤖 Generated with [Claude Code](https://claude.com/claude-code)