### PR TITLE
fix(resilience): resilience hardening — Firestore timeouts, quota bypass, pagination cap, token NPE, email validation

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/ConverterResource.java
+++ b/src/main/java/com/dime/api/feature/converter/ConverterResource.java
@@ -67,7 +67,9 @@ public class ConverterResource {
             @Context ContainerRequestContext requestContext) {
         long startTime = System.currentTimeMillis();
         String verifiedUid = (String) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_UID);
-        String email = (String) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_EMAIL);
+        String rawEmail = (String) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_EMAIL);
+        String email = rawEmail != null && rawEmail.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
+                ? rawEmail : null;
         String userId = verifiedUid != null ? verifiedUid : "anonymous";
         String domain = getDomain(headers);
         int fileCount = request.files != null ? request.files.size() : 0;

--- a/src/main/java/com/dime/api/feature/converter/NotionQuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/NotionQuotaService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.dime.api.feature.notion.NotionClient;
 import com.dime.api.feature.shared.BearerTokenUtil;
+import com.dime.api.feature.shared.exception.ExternalServiceException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -29,7 +30,7 @@ public class NotionQuotaService {
     NotionClient notionClient;
 
     @ConfigProperty(name = "notion.token")
-    String token;
+    Optional<String> token;
 
     @ConfigProperty(name = "notion.quota.database-id")
     Optional<String> quotaDbId;
@@ -54,7 +55,7 @@ public class NotionQuotaService {
             filter.put("property", "User ID");
             filter.putObject("title").put("equals", userId);
 
-            JsonNode response = notionClient.queryDatabase(BearerTokenUtil.ensureBearer(token), version, quotaDbId.get(), query);
+            JsonNode response = notionClient.queryDatabase(BearerTokenUtil.ensureBearer(token.orElseThrow(() -> new ExternalServiceException("Notion", "NOTION_TOKEN not configured", null))), version, quotaDbId.get(), query);
 
             if (response.has("results") && response.get("results").isArray() && response.get("results").size() > 0) {
                 return response.get("results").get(0).get("id").asText();
@@ -82,7 +83,7 @@ public class NotionQuotaService {
                 addRichTextProperty(properties, "Email", email);
             }
 
-            String authToken = BearerTokenUtil.ensureBearer(token);
+            String authToken = BearerTokenUtil.ensureBearer(token.orElseThrow(() -> new ExternalServiceException("Notion", "NOTION_TOKEN not configured", null)));
 
             if (pageId != null) {
                 ObjectNode updatePayload = objectMapper.createObjectNode();
@@ -113,7 +114,7 @@ public class NotionQuotaService {
                 if (cursor != null) {
                     query.put("start_cursor", cursor);
                 }
-                JsonNode response = notionClient.queryDatabase(BearerTokenUtil.ensureBearer(token), version, quotaDbId.get(), query);
+                JsonNode response = notionClient.queryDatabase(BearerTokenUtil.ensureBearer(token.orElseThrow(() -> new ExternalServiceException("Notion", "NOTION_TOKEN not configured", null))), version, quotaDbId.get(), query);
 
                 if (response.has("results") && response.get("results").isArray()) {
                     for (JsonNode page : response.get("results")) {
@@ -185,7 +186,7 @@ public class NotionQuotaService {
             if (pageId != null) {
                 ObjectNode properties = objectMapper.createObjectNode();
                 properties.put("archived", true);
-                notionClient.updatePage(BearerTokenUtil.ensureBearer(token), version, pageId, properties);
+                notionClient.updatePage(BearerTokenUtil.ensureBearer(token.orElseThrow(() -> new ExternalServiceException("Notion", "NOTION_TOKEN not configured", null))), version, pageId, properties);
                 log.info("Archived quota page in Notion for user {}", userId);
             }
         } catch (Exception e) {

--- a/src/main/java/com/dime/api/feature/converter/QuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaService.java
@@ -18,6 +18,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -87,7 +89,7 @@ public class QuotaService {
 
     public QuotaCheckResult checkQuota(@NonNull String userId, String email) {
         try {
-            DocumentSnapshot document = firestore().collection(COLLECTION_NAME).document(userId).get().get();
+            DocumentSnapshot document = firestore().collection(COLLECTION_NAME).document(userId).get().get(5, TimeUnit.SECONDS);
 
             if (!document.exists()) {
                 UserQuota newUser = createUser(userId, email);
@@ -136,13 +138,13 @@ public class QuotaService {
                     }
                 }
                 return null;
-            }).get();
+            }).get(10, TimeUnit.SECONDS);
 
             log.info("Incremented usage for user {}", userId);
 
             // Async sync to Notion (non-blocking)
             try {
-                DocumentSnapshot snapshot = docRef.get().get();
+                DocumentSnapshot snapshot = docRef.get().get(5, TimeUnit.SECONDS);
                 if (snapshot.exists()) {
                     UserQuota quota = snapshot.toObject(UserQuota.class);
                     if (quota != null) {
@@ -165,7 +167,7 @@ public class QuotaService {
 
     public UserQuota getQuotaStatus(@NonNull String userId) {
         try {
-            DocumentSnapshot document = firestore().collection(COLLECTION_NAME).document(userId).get().get();
+            DocumentSnapshot document = firestore().collection(COLLECTION_NAME).document(userId).get().get(5, TimeUnit.SECONDS);
             if (document.exists()) {
                 UserQuota userQuota = document.toObject(UserQuota.class);
                 if (userQuota != null && isNewMonth(userQuota.periodStart)) {
@@ -179,7 +181,7 @@ public class QuotaService {
         return null;
     }
 
-    private UserQuota createUser(@NonNull String userId, String email) throws ExecutionException, InterruptedException {
+    private UserQuota createUser(@NonNull String userId, String email) throws ExecutionException, InterruptedException, TimeoutException {
         Timestamp now = Timestamp.now();
         UserQuota newUser = new UserQuota(
                 DEFAULT_PLAN,
@@ -189,7 +191,7 @@ public class QuotaService {
                 now,
                 now);
         newUser.email = email;
-        firestore().collection(COLLECTION_NAME).document(userId).set(newUser).get();
+        firestore().collection(COLLECTION_NAME).document(userId).set(newUser).get(5, TimeUnit.SECONDS);
         log.info("Created new user {}", userId);
         return newUser;
     }
@@ -213,7 +215,7 @@ public class QuotaService {
             QuerySnapshot result = firestore().collection(COLLECTION_NAME)
                     .whereEqualTo("email", email)
                     .limit(1)
-                    .get().get();
+                    .get().get(5, TimeUnit.SECONDS);
             if (!result.isEmpty()) {
                 DocumentSnapshot doc = result.getDocuments().get(0);
                 return new UserQuotaWrapper(doc.getId(), doc.toObject(UserQuota.class));
@@ -245,7 +247,7 @@ public class QuotaService {
 
     public List<UserQuotaWrapper> findAll() {
         try {
-            return firestore().collection(COLLECTION_NAME).get().get().getDocuments()
+            return firestore().collection(COLLECTION_NAME).get().get(5, TimeUnit.SECONDS).getDocuments()
                     .stream()
                     .map(doc -> new UserQuotaWrapper(doc.getId(), doc.toObject(UserQuota.class)))
                     .collect(Collectors.toList());
@@ -258,7 +260,7 @@ public class QuotaService {
     public void updateQuota(@NonNull String userId, UserQuota quota) {
         try {
             quota.updatedAt = Timestamp.now();
-            firestore().collection(COLLECTION_NAME).document(userId).set(quota, SetOptions.merge()).get();
+            firestore().collection(COLLECTION_NAME).document(userId).set(quota, SetOptions.merge()).get(5, TimeUnit.SECONDS);
             log.info("Updated quota for user {}", userId);
 
             // Sync to Notion after update
@@ -301,13 +303,13 @@ public class QuotaService {
                             "updatedAt", now);
                 }
                 return null;
-            }).get();
+            }).get(10, TimeUnit.SECONDS);
 
             log.info("Updated plan for user {} → {} (limit={})", userId, plan, newLimit);
 
             // Async sync to Notion (non-blocking)
             try {
-                DocumentSnapshot snapshot = docRef.get().get();
+                DocumentSnapshot snapshot = docRef.get().get(5, TimeUnit.SECONDS);
                 if (snapshot.exists()) {
                     UserQuota quota = snapshot.toObject(UserQuota.class);
                     if (quota != null) {
@@ -328,7 +330,7 @@ public class QuotaService {
 
     public void deleteQuota(@NonNull String userId) {
         try {
-            firestore().collection(COLLECTION_NAME).document(userId).delete().get();
+            firestore().collection(COLLECTION_NAME).document(userId).delete().get(5, TimeUnit.SECONDS);
             log.info("Deleted quota for user {}", userId);
 
             // Delete from Notion after deletion
@@ -430,7 +432,7 @@ public class QuotaService {
                     transaction.update(docRef, updates);
                 }
                 return null;
-            }).get();
+            }).get(10, TimeUnit.SECONDS);
             log.info("Synced user {} from Notion to Firestore", data.userId());
         } catch (InterruptedException | ExecutionException e) {
             log.error("Error updating user {} from Notion data", data.userId(), e);

--- a/src/main/java/com/dime/api/feature/converter/QuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaService.java
@@ -98,8 +98,8 @@ public class QuotaService {
 
             UserQuota userQuota = document.toObject(UserQuota.class);
             if (userQuota == null) {
-                // Fallback if deserialization fails
-                return new QuotaCheckResult(true, 0, 0, DEFAULT_PLAN);
+                // Fallback if deserialization fails — deny to avoid quota bypass
+                return new QuotaCheckResult(false, 0, 0, DEFAULT_PLAN);
             }
 
             // Check for new month

--- a/src/main/java/com/dime/api/feature/converter/QuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaService.java
@@ -79,7 +79,7 @@ public class QuotaService {
         return firestoreInstance.get();
     }
 
-    public void updateQuotaLimit(PlanType plan, long newLimit) {
+    public synchronized void updateQuotaLimit(PlanType plan, long newLimit) {
         EnumMap<PlanType, Long> mutable = new EnumMap<>(PlanType.class);
         mutable.putAll(quotaLimits);
         mutable.put(plan, newLimit);

--- a/src/main/java/com/dime/api/feature/converter/TrackingService.java
+++ b/src/main/java/com/dime/api/feature/converter/TrackingService.java
@@ -156,6 +156,8 @@ public class TrackingService {
             int totalEventCount = 0;
             boolean hasMore;
             String nextCursor = null;
+            int pageCount = 0;
+            final int MAX_PAGES = 1000;
 
             do {
                 ObjectNode query = baseQuery.deepCopy();
@@ -182,7 +184,8 @@ public class TrackingService {
                 nextCursor = nextCursorNode != null && !nextCursorNode.isNull()
                         ? nextCursorNode.asText()
                         : null;
-            } while (hasMore && nextCursor != null && !nextCursor.isBlank());
+                pageCount++;
+            } while (hasMore && nextCursor != null && !nextCursor.isBlank() && pageCount < MAX_PAGES);
 
             log.info("Fetched statistics from Notion: fileCount={}, eventCount={}", totalFileCount, totalEventCount);
             Statistics stats = new Statistics(totalFileCount, totalEventCount);

--- a/src/main/java/com/dime/api/feature/shared/FirestoreCacheService.java
+++ b/src/main/java/com/dime/api/feature/shared/FirestoreCacheService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @ApplicationScoped
@@ -32,7 +33,7 @@ public class FirestoreCacheService {
 
     public <T> Optional<T> read(String key, Class<T> type) {
         try {
-            DocumentSnapshot doc = firestore().collection(COLLECTION).document(key).get().get();
+            DocumentSnapshot doc = firestore().collection(COLLECTION).document(key).get().get(5, TimeUnit.SECONDS);
             if (doc.exists()) {
                 String json = doc.getString("data");
                 if (json != null) {
@@ -47,7 +48,7 @@ public class FirestoreCacheService {
 
     public <T> Optional<T> read(String key, TypeReference<T> type) {
         try {
-            DocumentSnapshot doc = firestore().collection(COLLECTION).document(key).get().get();
+            DocumentSnapshot doc = firestore().collection(COLLECTION).document(key).get().get(5, TimeUnit.SECONDS);
             if (doc.exists()) {
                 String json = doc.getString("data");
                 if (json != null) {
@@ -65,7 +66,7 @@ public class FirestoreCacheService {
             try {
                 String json = objectMapper.writeValueAsString(data);
                 firestore().collection(COLLECTION).document(key)
-                        .set(Map.of("data", json, "updatedAt", Timestamp.now())).get();
+                        .set(Map.of("data", json, "updatedAt", Timestamp.now())).get(10, TimeUnit.SECONDS);
                 log.debug("Written cache to Firestore for key: {}", key);
             } catch (Throwable t) {
                 log.warn("Failed to write cache to Firestore for key: {}", key, t);


### PR DESCRIPTION
## Summary
- Add 5s/10s timeouts to all blocking Firestore calls in `QuotaService` and `FirestoreCacheService`
- Fix null quota deserialization returning `allowed=true` — now returns `allowed=false` to prevent quota bypass
- Synchronize `updateQuotaLimit()` to prevent lost updates under concurrency
- Cap Notion pagination at 1000 pages in `TrackingService` to prevent infinite loops
- Change `NotionQuotaService.token` from plain `String` to `Optional` with fail-fast on missing config
- Validate email format from Firebase token before persisting to Firestore/Notion

## Test plan
- [ ] `mvn test` passes
- [ ] `POST /v1/converter` quota check works correctly for new and existing users
- [ ] Corrupt Firestore quota doc returns 429 instead of allowing the request
- [ ] `PUT /v1/users/plans/PRO?limit=50` still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)