### PR TITLE
fix(quality): code quality — plan validation, countEvents guard, remove cleanIcs wrappers, OWASP plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,13 @@
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
         <version>12.2.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>com.google.cloud.tools</groupId>

--- a/src/main/java/com/dime/api/feature/converter/ClaudeService.java
+++ b/src/main/java/com/dime/api/feature/converter/ClaudeService.java
@@ -128,7 +128,7 @@ public class ClaudeService {
             JsonNode firstContent = response.get("content").get(0);
             if (firstContent != null && firstContent.has("text")) {
                 String text = firstContent.get("text").asText();
-                return cleanIcs(text);
+                return IcsUtils.cleanIcs(text);
             }
         }
 
@@ -136,7 +136,4 @@ public class ClaudeService {
         throw new ProcessingException("Claude API returned unexpected response format");
     }
 
-    String cleanIcs(String text) {
-        return IcsUtils.cleanIcs(text);
-    }
 }

--- a/src/main/java/com/dime/api/feature/converter/ConverterResource.java
+++ b/src/main/java/com/dime/api/feature/converter/ConverterResource.java
@@ -222,6 +222,7 @@ public class ConverterResource {
     }
 
     private int countEvents(String ics) {
+        if (ics.length() > 10_000_000) return -1;
         return ics.split("BEGIN:VEVENT").length - 1;
     }
 

--- a/src/main/java/com/dime/api/feature/converter/GeminiService.java
+++ b/src/main/java/com/dime/api/feature/converter/GeminiService.java
@@ -132,7 +132,7 @@ public class GeminiService {
                 JsonNode responseParts = candidate.get("content").get("parts");
                 if (responseParts.size() > 0 && responseParts.get(0).has("text")) {
                     String text = responseParts.get(0).get("text").asText();
-                    return cleanIcs(text);
+                    return IcsUtils.cleanIcs(text);
                 }
             }
         }
@@ -167,7 +167,4 @@ public class GeminiService {
         return cachedCredentials.getAccessToken().getTokenValue();
     }
 
-    String cleanIcs(String text) {
-        return IcsUtils.cleanIcs(text);
-    }
 }

--- a/src/main/java/com/dime/api/feature/converter/UserQuotaResource.java
+++ b/src/main/java/com/dime/api/feature/converter/UserQuotaResource.java
@@ -1,6 +1,8 @@
 package com.dime.api.feature.converter;
 
+import com.dime.api.feature.shared.exception.ValidationException;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -99,9 +101,14 @@ public class UserQuotaResource {
     @Path("/plans/{plan}")
     @Operation(summary = "Update plan limit", description = "Updates the quota limit for a specific plan (in-memory, resets on restart)")
     @APIResponse(responseCode = "204", description = "Plan limit updated")
-    public Response updatePlanLimit(@PathParam("plan") String plan, @QueryParam("limit") @NotNull long limit) {
+    public Response updatePlanLimit(@PathParam("plan") String plan, @QueryParam("limit") @NotNull @Min(1) long limit) {
         log.info("PUT /users/plans/{} called with limit={}", plan, limit);
-        PlanType planType = PlanType.fromString(plan);
+        PlanType planType;
+        try {
+            planType = PlanType.valueOf(plan.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ValidationException("Unknown plan: " + plan + ". Valid values: FREE, PRO, BUSINESS, UNLIMITED");
+        }
         quotaService.updateQuotaLimit(planType, limit);
         return Response.noContent().build();
     }


### PR DESCRIPTION
## Summary
- Validate `plan` path param in `updatePlanLimit` — throw 400 for unknown values (was silently defaulting to FREE)
- Add `@Min(1)` constraint to `limit` query param to reject negative/zero quota limits
- Guard `countEvents()` against OOM on oversized ICS strings (>10MB)
- Remove dead `cleanIcs()` wrapper methods in `GeminiService` and `ClaudeService`, call `IcsUtils.cleanIcs()` directly
- Bind OWASP dependency-check plugin to `verify` phase so `mvn verify` actually runs the CVE check

> Note: Stripe SDK version (32.1.0) could not be verified on Maven Central — skipping update to avoid build breakage.

## Test plan
- [ ] `mvn test` passes
- [ ] `PUT /v1/users/plans/INVALID?limit=10` returns 400 Bad Request
- [ ] `PUT /v1/users/plans/PRO?limit=-1` returns 400 Bad Request
- [ ] `PUT /v1/users/plans/PRO?limit=50` returns 204 as expected
- [ ] `mvn verify` runs OWASP dependency check

🤖 Generated with [Claude Code](https://claude.com/claude-code)