### PR TITLE
fix(tests): update tests broken by audit fixes

### DIFF
--- a/src/test/java/com/dime/api/feature/converter/ClaudeServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/ClaudeServiceTest.java
@@ -2,6 +2,7 @@ package com.dime.api.feature.converter;
 
 import com.dime.api.feature.shared.exception.ExternalServiceException;
 import com.dime.api.feature.shared.exception.ProcessingException;
+import com.dime.api.feature.converter.IcsUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +38,7 @@ public class ClaudeServiceTest {
     @Test
     public void testCleanIcs_removesMarkdownIcsBlock() {
         String dirty = "```ics\nBEGIN:VCALENDAR\nSUMMARY:Test\nEND:VCALENDAR\n```";
-        String cleaned = service.cleanIcs(dirty);
+        String cleaned = IcsUtils.cleanIcs(dirty);
         assertNotNull(cleaned);
         assertFalse(cleaned.contains("```"));
         assertTrue(cleaned.contains("BEGIN:VCALENDAR"));
@@ -46,7 +47,7 @@ public class ClaudeServiceTest {
     @Test
     public void testCleanIcs_removesGenericCodeBlock() {
         String dirty = "```\nBEGIN:VCALENDAR\nEND:VCALENDAR\n```";
-        String cleaned = service.cleanIcs(dirty);
+        String cleaned = IcsUtils.cleanIcs(dirty);
         assertFalse(cleaned.contains("```"));
         assertTrue(cleaned.contains("BEGIN:VCALENDAR"));
     }
@@ -54,12 +55,12 @@ public class ClaudeServiceTest {
     @Test
     public void testCleanIcs_alreadyClean() {
         String clean = "BEGIN:VCALENDAR\nSUMMARY:Test\nEND:VCALENDAR";
-        assertEquals(clean, service.cleanIcs(clean));
+        assertEquals(clean, IcsUtils.cleanIcs(clean));
     }
 
     @Test
     public void testCleanIcs_null() {
-        assertNull(service.cleanIcs(null));
+        assertNull(IcsUtils.cleanIcs(null));
     }
 
     // --- generateIcs: API key validation ---

--- a/src/test/java/com/dime/api/feature/converter/GeminiServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/GeminiServiceTest.java
@@ -36,7 +36,7 @@ public class GeminiServiceTest {
     @Test
     public void testCleanIcs() {
         String dirty = "BEGIN:VCALENDAR\nSUMMARY:Test\nEND:VCALENDAR";
-        String cleaned = geminiService.cleanIcs(dirty);
+        String cleaned = IcsUtils.cleanIcs(dirty);
         assertNotNull(cleaned);
         assertTrue(cleaned.contains("VCALENDAR"));
     }
@@ -90,7 +90,7 @@ public class GeminiServiceTest {
         @Test
         void testCleanIcs_removesMarkdownIcsBlock() {
             String dirty = "```ics\nBEGIN:VCALENDAR\nSUMMARY:Test\nEND:VCALENDAR\n```";
-            String cleaned = service.cleanIcs(dirty);
+            String cleaned = IcsUtils.cleanIcs(dirty);
             assertNotNull(cleaned);
             assertFalse(cleaned.contains("```"));
             assertTrue(cleaned.contains("BEGIN:VCALENDAR"));
@@ -99,7 +99,7 @@ public class GeminiServiceTest {
         @Test
         void testCleanIcs_removesGenericCodeBlock() {
             String dirty = "```\nBEGIN:VCALENDAR\nEND:VCALENDAR\n```";
-            String cleaned = service.cleanIcs(dirty);
+            String cleaned = IcsUtils.cleanIcs(dirty);
             assertFalse(cleaned.contains("```"));
             assertTrue(cleaned.contains("BEGIN:VCALENDAR"));
         }
@@ -107,12 +107,12 @@ public class GeminiServiceTest {
         @Test
         void testCleanIcs_alreadyClean() {
             String clean = "BEGIN:VCALENDAR\nSUMMARY:Test\nEND:VCALENDAR";
-            assertEquals(clean, service.cleanIcs(clean));
+            assertEquals(clean, IcsUtils.cleanIcs(clean));
         }
 
         @Test
         void testCleanIcs_null() {
-            assertNull(service.cleanIcs(null));
+            assertNull(IcsUtils.cleanIcs(null));
         }
 
         // --- generateIcs: successful responses ---

--- a/src/test/java/com/dime/api/feature/converter/NotionQuotaServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/NotionQuotaServiceTest.java
@@ -31,7 +31,7 @@ public class NotionQuotaServiceTest {
         notionQuotaService = new NotionQuotaService();
         notionQuotaService.notionClient = notionClient;
         notionQuotaService.objectMapper = objectMapper;
-        notionQuotaService.token = "dummy-token";
+        notionQuotaService.token = Optional.of("dummy-token");
         notionQuotaService.version = "2022-06-28";
         notionQuotaService.quotaDbId = Optional.of("dummy-db-id");
     }


### PR DESCRIPTION
## Summary
- Replace `service.cleanIcs()` / `geminiService.cleanIcs()` calls in tests with `IcsUtils.cleanIcs()` — the wrapper methods were removed in the code-quality PR
- Fix `notionQuotaService.token = "dummy-token"` → `Optional.of("dummy-token")` — the field was changed to `Optional<String>` in the resilience PR

## Note
`RootResourceTest` has 1 pre-existing failure (login redirect header) unrelated to these changes — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)