### PR TITLE
[codex] Keep Cloud Run API warm

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,6 +35,8 @@ steps:
       - '$_REGION'
       - '--platform'
       - 'managed'
+      - '--min-instances'
+      - '1'
       - '--update-env-vars'
       - 'FIRESTORE_ENABLE_TRACING=false'
 


### PR DESCRIPTION
## Summary

- Add `--min-instances 1` to the Cloud Run deploy step in `cloudbuild.yaml`.
- Keep one `dime-api` instance warm after deployments so the service does not scale to zero during idle periods.

## Why

CLI timing showed the first public API requests after idle were around 8 seconds, while warmed requests were around 250 ms. The service already had `startup-cpu-boost` enabled, but no `minScale`, so Cloud Run could still scale down to zero.

## Impact

This makes the Cloud Run setting durable across future Cloud Build deployments and preserves the first-visit latency improvement tested manually.

Expected cost impact is roughly -10/month gross for the current `1 vCPU` / `512 MiB` service in `europe-west1`, before any applicable free tier.

## Validation

- Confirmed current Cloud Run revision has `autoscaling.knative.dev/minScale: 1`.
- Measured warmed endpoints around 230-260 ms after enabling `min-instances=1`.

## Follow-up

A bootstrap/snapshot endpoint can further reduce latency immediately after a fresh deployment, before in-memory caches are warm.