### PR TITLE
[codex] Fix email in Notion conversion notifications

### DIFF
--- a/src/main/java/com/dime/api/feature/converter/ConverterResource.java
+++ b/src/main/java/com/dime/api/feature/converter/ConverterResource.java
@@ -97,7 +97,7 @@ public class ConverterResource {
         // Check Quota
         QuotaService.QuotaCheckResult quota = quotaService.checkQuota(userId, email);
         if (!quota.allowed()) {
-            trackingService.logQuotaExceeded(userId, (int) (quota.limit() - quota.remaining()), (int) quota.limit(),
+            trackingService.logQuotaExceeded(userId, email, (int) (quota.limit() - quota.remaining()), (int) quota.limit(),
                     quota.plan().toString(), domain);
 
             throw new QuotaException("You've reached your monthly conversion limit. Limit: " + quota.limit(),
@@ -111,7 +111,7 @@ public class ConverterResource {
                     : claudeService.generateIcs(request);
 
             if (icsContent == null || icsContent.isEmpty() || icsContent.equalsIgnoreCase("null")) {
-                trackingService.logConversionError(userId, fileCount, "No events found in images",
+                trackingService.logConversionError(userId, email, fileCount, "No events found in images",
                         System.currentTimeMillis() - startTime, domain);
                 throw new ProcessingException("No calendar events found in the provided images. " +
                         "Please ensure the images contain clear calendar information.",
@@ -119,7 +119,7 @@ public class ConverterResource {
             }
 
             if (!isValidIcs(icsContent)) {
-                trackingService.logConversionError(userId, fileCount, "Generated ICS is invalid",
+                trackingService.logConversionError(userId, email, fileCount, "Generated ICS is invalid",
                         System.currentTimeMillis() - startTime, domain);
                 throw new ProcessingException(
                         "The AI generated invalid calendar data. Please try again with clearer images.",
@@ -129,14 +129,14 @@ public class ConverterResource {
             // Success
             int eventCount = countEvents(icsContent);
             quotaService.incrementUsage(userId, email);
-            trackingService.logConversion(userId, fileCount, domain, eventCount,
+            trackingService.logConversion(userId, email, fileCount, domain, eventCount,
                     System.currentTimeMillis() - startTime);
 
             return Response.ok(new ConverterResponse(true, icsContent)).build();
 
         } catch (IOException e) {
             log.error("Error processing conversion request for user {}: {}", userId, e.getMessage(), e);
-            trackingService.logConversionError(userId, fileCount, e.getMessage(),
+            trackingService.logConversionError(userId, email, fileCount, e.getMessage(),
                     System.currentTimeMillis() - startTime, domain);
             throw new ProcessingException("Failed to process images for conversion: " + e.getMessage(), e);
         }

--- a/src/main/java/com/dime/api/feature/converter/TrackingService.java
+++ b/src/main/java/com/dime/api/feature/converter/TrackingService.java
@@ -64,20 +64,20 @@ public class TrackingService {
         return notionToken.isPresent() && trackingDbId.isPresent();
     }
 
-    public void logConversion(String userId, int fileCount, String domain, int eventCount, long duration) {
-        logEvent("conversion", userId, "Success", fileCount, eventCount, duration, null, domain);
+    public void logConversion(String userId, String email, int fileCount, String domain, int eventCount, long duration) {
+        logEvent("conversion", userId, email, "Success", fileCount, eventCount, duration, null, domain);
     }
 
-    public void logConversionError(String userId, int fileCount, String errorMessage, long duration, String domain) {
-        logEvent("conversion", userId, "Error", fileCount, 0, duration, errorMessage, domain);
+    public void logConversionError(String userId, String email, int fileCount, String errorMessage, long duration, String domain) {
+        logEvent("conversion", userId, email, "Error", fileCount, 0, duration, errorMessage, domain);
     }
 
-    public void logQuotaExceeded(String userId, int usageCount, int limit, String plan, String domain) {
+    public void logQuotaExceeded(String userId, String email, int usageCount, int limit, String plan, String domain) {
         String errorMessage = String.format("Quota exceeded: %d/%d (plan: %s)", usageCount, limit, plan);
-        logEvent("quota_exceeded", userId, "Error", usageCount, limit, 0, errorMessage, domain);
+        logEvent("quota_exceeded", userId, email, "Error", usageCount, limit, 0, errorMessage, domain);
     }
 
-    private void logEvent(String action, String userId, String status, int fileCount, int eventCount, long duration,
+    private void logEvent(String action, String userId, String email, String status, int fileCount, int eventCount, long duration,
             String errorMessage, String domain) {
         if (!isEnabled()) {
             log.debug("Tracking disabled: Notion token or DB ID missing");
@@ -92,6 +92,9 @@ public class TrackingService {
             ObjectNode properties = objectMapper.createObjectNode();
             addTitleProperty(properties, "Action", action);
             addRichTextProperty(properties, "User ID", userId);
+            if (email != null && !email.isBlank()) {
+                addRichTextProperty(properties, "Email", email);
+            }
             addDateProperty(properties, "Timestamp", Instant.now().toString());
             addSelectProperty(properties, "Status", status);
 

--- a/src/test/java/com/dime/api/feature/converter/TrackingServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/TrackingServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -89,27 +90,42 @@ public class TrackingServiceTest {
 
         @Test
         void logConversion_whenEnabled_callsNotionClient() {
-            service.logConversion("user1", 2, "test.com", 3, 500L);
-            verify(mockNotionClient, times(1)).createPage(any(), any(), any());
+            service.logConversion("user1", "user@example.com", 2, "test.com", 3, 500L);
+
+            ArgumentCaptor<ObjectNode> pageCaptor = ArgumentCaptor.forClass(ObjectNode.class);
+            verify(mockNotionClient).createPage(any(), any(), pageCaptor.capture());
+
+            ObjectNode properties = (ObjectNode) pageCaptor.getValue().get("properties");
+            assertEquals("user@example.com",
+                    properties.get("Email").get("rich_text").get(0).get("text").get("content").asText());
         }
 
         @Test
         void logConversion_whenDisabled_neverCallsNotionClient() {
             service.notionToken = Optional.empty();
-            service.logConversion("user1", 2, "test.com", 3, 500L);
+            service.logConversion("user1", "user@example.com", 2, "test.com", 3, 500L);
             verify(mockNotionClient, never()).createPage(any(), any(), any());
+        }
+
+        @Test
+        void logConversion_withoutEmail_omitsEmailProperty() {
+            service.logConversion("anonymous", null, 1, "test.com", 1, 100L);
+
+            ArgumentCaptor<ObjectNode> pageCaptor = ArgumentCaptor.forClass(ObjectNode.class);
+            verify(mockNotionClient).createPage(any(), any(), pageCaptor.capture());
+            assertFalse(pageCaptor.getValue().get("properties").has("Email"));
         }
 
         @Test
         void logConversionError_longMessage_isTruncatedAndDoesNotThrow() {
             String longMessage = "e".repeat(2001);
-            assertDoesNotThrow(() -> service.logConversionError("user1", 1, longMessage, 100L, "test.com"));
+            assertDoesNotThrow(() -> service.logConversionError("user1", "user@example.com", 1, longMessage, 100L, "test.com"));
             verify(mockNotionClient, times(1)).createPage(any(), any(), any());
         }
 
         @Test
         void logQuotaExceeded_whenEnabled_callsNotionClient() {
-            service.logQuotaExceeded("user1", 10, 10, "FREE", "test.com");
+            service.logQuotaExceeded("user1", "user@example.com", 10, 10, "FREE", "test.com");
             verify(mockNotionClient, times(1)).createPage(any(), any(), any());
         }
 

--- a/src/test/java/com/dime/api/feature/converter/TrackingServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/TrackingServiceTest.java
@@ -8,9 +8,9 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Optional;
-import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -91,13 +91,7 @@ public class TrackingServiceTest {
         @Test
         void logConversion_whenEnabled_callsNotionClient() {
             service.logConversion("user1", "user@example.com", 2, "test.com", 3, 500L);
-
-            ArgumentCaptor<ObjectNode> pageCaptor = ArgumentCaptor.forClass(ObjectNode.class);
-            verify(mockNotionClient).createPage(any(), any(), pageCaptor.capture());
-
-            ObjectNode properties = (ObjectNode) pageCaptor.getValue().get("properties");
-            assertEquals("user@example.com",
-                    properties.get("Email").get("rich_text").get(0).get("text").get("content").asText());
+            assertTrackedEmail("user@example.com");
         }
 
         @Test
@@ -120,13 +114,13 @@ public class TrackingServiceTest {
         void logConversionError_longMessage_isTruncatedAndDoesNotThrow() {
             String longMessage = "e".repeat(2001);
             assertDoesNotThrow(() -> service.logConversionError("user1", "user@example.com", 1, longMessage, 100L, "test.com"));
-            verify(mockNotionClient, times(1)).createPage(any(), any(), any());
+            assertTrackedEmail("user@example.com");
         }
 
         @Test
         void logQuotaExceeded_whenEnabled_callsNotionClient() {
             service.logQuotaExceeded("user1", "user@example.com", 10, 10, "FREE", "test.com");
-            verify(mockNotionClient, times(1)).createPage(any(), any(), any());
+            assertTrackedEmail("user@example.com");
         }
 
         @Test
@@ -144,6 +138,15 @@ public class TrackingServiceTest {
             TrackingService.Statistics stats = service.getStatistics();
             assertEquals(0, stats.fileCount());
             assertEquals(0, stats.eventCount());
+        }
+
+        private void assertTrackedEmail(String expectedEmail) {
+            ArgumentCaptor<ObjectNode> pageCaptor = ArgumentCaptor.forClass(ObjectNode.class);
+            verify(mockNotionClient).createPage(any(), any(), pageCaptor.capture());
+
+            ObjectNode properties = (ObjectNode) pageCaptor.getValue().get("properties");
+            assertEquals(expectedEmail,
+                    properties.get("Email").get("rich_text").get(0).get("text").get("content").asText());
         }
     }
 }


### PR DESCRIPTION
## What changed

- Pass the verified Firebase email from `ConverterResource` into conversion tracking calls.
- Add the email as a Notion `Email` rich-text property for successful conversions, conversion errors, and quota-exceeded events.
- Omit the property for anonymous users without an email.
- Add tests that assert the generated Notion payload includes or omits `Email` appropriately.

## Root cause

The backend already extracted the email from the Firebase ID token and stored it in the user quota database, but `ConverterResource` did not pass that value to `TrackingService`. Conversion notification pages were therefore created without an `Email` property.

## Impact

Notion conversion notifications now show the authenticated user email.

## Validation

- Live Notion notification received with the email populated.
- `/opt/homebrew/bin/mvn -Dtest=TrackingServiceTest test`: 13 passed, 0 failed.
- `git diff --check` passed.

Quarkus emitted existing Firestore/OpenTelemetry cache-warmup warnings; the build and focused tests completed successfully.