### PR TITLE
[codex] Add required API CI and deterministic packaging checks

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,0 +1,88 @@
+name: API CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/api-ci.yml"
+      - "pom.xml"
+      - "src/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: api-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-and-package:
+    name: Java 21 tests and package
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    env:
+      MAVEN_OPTS: -Djava.awt.headless=true
+      GITHUB_TOKEN: ""
+      NOTION_TOKEN: ""
+      NOTION_TRACKING_DB_ID: ""
+      NOTION_CMS_DB_ID: ""
+      NOTION_QUOTA_DB_ID: ""
+      GEMINI_API_KEY: ""
+      CLAUDE_API_KEY: ""
+      STRIPE_SECRET_KEY: ""
+      STRIPE_WEBHOOK_SECRET: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Run tests and package
+        run: mvn -B -ntp clean verify
+
+      - name: Capture first package manifest
+        run: |
+          test -f target/3dime-api-runner.jar
+          test -s target/3dime-api-runner.jar
+          jar tf target/3dime-api-runner.jar | sort > /tmp/3dime-api-runner.first.manifest
+
+      - name: Rebuild package for deterministic manifest check
+        run: mvn -B -ntp clean package -DskipTests
+
+      - name: Compare package manifests
+        run: |
+          test -f target/3dime-api-runner.jar
+          test -s target/3dime-api-runner.jar
+          jar tf target/3dime-api-runner.jar | sort > /tmp/3dime-api-runner.second.manifest
+          diff -u /tmp/3dime-api-runner.first.manifest /tmp/3dime-api-runner.second.manifest
+
+      - name: Publish test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-test-reports
+          path: |
+            target/surefire-reports/**
+            target/failsafe-reports/**
+          if-no-files-found: ignore
+
+      - name: Publish failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-failure-logs
+          path: |
+            target/**/*.log
+            target/**/*dump*
+            target/**/*jvmRun*
+            /tmp/3dime-api-runner.*.manifest
+          if-no-files-found: ignore

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -25,15 +25,10 @@ jobs:
 
     env:
       MAVEN_OPTS: -Djava.awt.headless=true
-      GITHUB_TOKEN: ""
-      NOTION_TOKEN: ""
-      NOTION_TRACKING_DB_ID: ""
-      NOTION_CMS_DB_ID: ""
-      NOTION_QUOTA_DB_ID: ""
-      GEMINI_API_KEY: ""
-      CLAUDE_API_KEY: ""
-      STRIPE_SECRET_KEY: ""
-      STRIPE_WEBHOOK_SECRET: ""
+      NOTION_TOKEN: test-notion-token
+      NOTION_TRACKING_DB_ID: test-tracking-db-id
+      NOTION_CMS_DB_ID: test-cms-db-id
+      NOTION_QUOTA_DB_ID: test-quota-db-id
 
     steps:
       - name: Checkout

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,85 @@
+name: Security Scan
+
+on:
+  schedule:
+    - cron: "24 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: security-scan-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  dependency-scan:
+    name: Maven dependency scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Run OWASP Dependency-Check
+        run: mvn -B -ntp -Psecurity-scan verify -DskipTests
+
+      - name: Upload dependency scan report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: target/dependency-check-report.*
+          if-no-files-found: ignore
+
+      - name: Upload dependency SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: target/dependency-check-report.sarif
+        continue-on-error: true
+
+  container-scan:
+    name: Container image scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build local image
+        run: docker build --pull --tag 3dime-api:${{ github.sha }} .
+
+      - name: Run Trivy scan
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: 3dime-api:${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Upload container SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+        continue-on-error: true
+
+      - name: Upload container scan report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-container-report
+          path: trivy-results.sarif
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run -p 8080:8080 \
 
 ## 📚 Documentation
 
-[API Reference](docs/api.md), [Configuration](docs/configuration.md), [Architecture](docs/architecture.md), [Deployment](docs/deployment.md), [Health Monitoring](docs/health.md), [Security](docs/security.md)
+[API Reference](docs/api.md), [Configuration](docs/configuration.md), [Architecture](docs/architecture.md), [Deployment](docs/deployment.md), [Health Monitoring](docs/health.md), [Security](docs/security.md), [CI](docs/ci.md)
 
 ---
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,65 @@
+# CI and Packaging
+
+## Pull Request Checks
+
+`API CI / Java 21 tests and package` runs for pull requests targeting `main` when API source,
+Maven, or workflow files change.
+
+The job uses Java 21 and runs:
+
+```bash
+mvn -B -ntp clean verify
+```
+
+It then rebuilds the application package and compares the sorted entry manifest for
+`target/3dime-api-runner.jar`:
+
+```bash
+mvn -B -ntp clean package -DskipTests
+```
+
+The package comparison protects against accidental packaging drift while preserving the existing
+Quarkus uber-JAR deployment contract. Test reports from `target/surefire-reports` and
+`target/failsafe-reports` are uploaded on every run. Failure logs and Maven dump files are uploaded
+when a check fails.
+
+## Test Profile Isolation
+
+The `%test` profile disables startup cache warmups, OpenTelemetry exporters, and live REST-client
+base URLs so CI tests do not require Firestore, Notion, Stripe, GitHub, Gemini, Claude, or Google
+Cloud Trace credentials. Maven test runs also set `dotenv.enabled=false` so local `.env` secrets do
+not leak into the test profile. Tests that exercise integrations must mock clients or service fields
+directly.
+
+## Scheduled Security Scans
+
+`Security Scan` runs weekly on Mondays at 04:24 UTC and can also be started manually.
+
+It publishes:
+
+- OWASP Dependency-Check HTML, JSON, and SARIF reports.
+- Trivy container SARIF reports for the Docker image built from the current repository state.
+
+Dependency-Check is intentionally isolated behind the `security-scan` Maven profile so vulnerability
+database availability does not make normal PR builds non-deterministic.
+
+## Ownership and Triage
+
+The maintainer on rotation owns weekly scan review.
+
+1. Review GitHub code scanning alerts and workflow artifacts after each scheduled run.
+2. Open or update one issue per actionable dependency or container finding.
+3. Label each issue with `security` plus the affected area, such as `java`, `config`, or `docker`.
+4. Mark the issue priority from exploitability, reachability, and available fixes.
+5. Close the issue only after the fix merges and the next scan no longer reports the finding.
+
+## Required Branch Protection
+
+Configure `main` to require this status check before merge:
+
+```text
+API CI / Java 21 tests and package
+```
+
+Keep `Security Scan` out of required pull-request checks because it is scheduled reporting and may
+depend on external vulnerability feeds.

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
 
     <!-- Maven Plugin Versions -->
     <compiler-plugin.version>3.15.0</compiler-plugin.version>
+    <dependency-plugin.version>3.9.0</dependency-plugin.version>
     <surefire-plugin.version>3.5.6</surefire-plugin.version>
     <enforcer-plugin.version>3.6.3</enforcer-plugin.version>
 
@@ -242,10 +243,24 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${dependency-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire-plugin.version}</version>
         <configuration>
+          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
           <systemPropertyVariables>
+            <dotenv.enabled>false</dotenv.enabled>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
@@ -261,7 +276,9 @@
               <goal>verify</goal>
             </goals>
             <configuration>
+              <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
               <systemPropertyVariables>
+                <dotenv.enabled>false</dotenv.enabled>
                 <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                 <maven.home>${maven.home}</maven.home>
@@ -274,13 +291,6 @@
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
         <version>12.2.2</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
@@ -336,6 +346,33 @@
         <skipITs>false</skipITs>
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
+    </profile>
+    <profile>
+      <id>security-scan</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>12.2.2</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <formats>
+                <format>HTML</format>
+                <format>JSON</format>
+                <format>SARIF</format>
+              </formats>
+              <failBuildOnCVSS>9.0</failBuildOnCVSS>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
+++ b/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -24,7 +25,15 @@ public class CacheWarmup {
     @Inject
     TrackingService trackingService;
 
+    @ConfigProperty(name = "cache.warmup.enabled", defaultValue = "true")
+    boolean warmupEnabled;
+
     void onStart(@Observes StartupEvent event) {
+        if (!warmupEnabled) {
+            log.info("Cache warmup disabled by configuration");
+            return;
+        }
+
         log.info("Starting cache warmup...");
         CompletableFuture.runAsync(this::runWarmupPhases);
     }

--- a/src/main/java/com/dime/api/feature/shared/config/DotEnvConfigSource.java
+++ b/src/main/java/com/dime/api/feature/shared/config/DotEnvConfigSource.java
@@ -14,17 +14,19 @@ public class DotEnvConfigSource implements ConfigSource {
 
     public DotEnvConfigSource() {
         Map<String, String> loadedProperties = new HashMap<>();
-        try {
-            // Load .env file, ignoring if missing
-            Dotenv dotenv = Dotenv.configure()
-                    .ignoreIfMissing()
-                    .load();
+        if (Boolean.parseBoolean(System.getProperty("dotenv.enabled", "true"))) {
+            try {
+                // Load .env file, ignoring if missing
+                Dotenv dotenv = Dotenv.configure()
+                        .ignoreIfMissing()
+                        .load();
 
-            for (io.github.cdimascio.dotenv.DotenvEntry entry : dotenv.entries()) {
-                loadedProperties.put(entry.getKey(), entry.getValue());
+                for (io.github.cdimascio.dotenv.DotenvEntry entry : dotenv.entries()) {
+                    loadedProperties.put(entry.getKey(), entry.getValue());
+                }
+            } catch (Exception e) {
+                // Ignore errors loading .env
             }
-        } catch (Exception e) {
-            // Ignore errors loading .env
         }
         this.properties = Collections.unmodifiableMap(loadedProperties);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,11 +23,17 @@ quarkus.rest-client."com.dime.api.feature.github.GitHubClient".url=${github.api.
 quarkus.rest-client."com.dime.api.feature.github.GitHubClient".scope=jakarta.inject.Singleton
 quarkus.rest-client."com.dime.api.feature.github.GitHubClient".connect-timeout=5000
 quarkus.rest-client."com.dime.api.feature.github.GitHubClient".read-timeout=12000
+%test.quarkus.rest-client."com.dime.api.feature.github.GitHubClient".url=http://127.0.0.1:1
+%test.quarkus.rest-client."com.dime.api.feature.github.GitHubClient".connect-timeout=100
+%test.quarkus.rest-client."com.dime.api.feature.github.GitHubClient".read-timeout=100
 
 quarkus.rest-client."notion-api".url=https://api.notion.com
 quarkus.rest-client."notion-api".scope=jakarta.inject.Singleton
 quarkus.rest-client."notion-api".connect-timeout=5000
 quarkus.rest-client."notion-api".read-timeout=12000
+%test.quarkus.rest-client."notion-api".url=http://127.0.0.1:1
+%test.quarkus.rest-client."notion-api".connect-timeout=100
+%test.quarkus.rest-client."notion-api".read-timeout=100
 
 # Notion Configuration
 notion.token=${NOTION_TOKEN}
@@ -47,6 +53,9 @@ quarkus.rest-client."gemini-api".url=https://generativelanguage.googleapis.com
 quarkus.rest-client."gemini-api".scope=jakarta.inject.Singleton
 quarkus.rest-client."gemini-api".connect-timeout=5000
 quarkus.rest-client."gemini-api".read-timeout=65000
+%test.quarkus.rest-client."gemini-api".url=http://127.0.0.1:1
+%test.quarkus.rest-client."gemini-api".connect-timeout=100
+%test.quarkus.rest-client."gemini-api".read-timeout=100
 
 # Claude Configuration
 claude.model=${CLAUDE_MODEL:claude-sonnet-4-5}
@@ -59,6 +68,9 @@ quarkus.rest-client."claude-api".url=https://api.anthropic.com
 quarkus.rest-client."claude-api".scope=jakarta.inject.Singleton
 quarkus.rest-client."claude-api".connect-timeout=5000
 quarkus.rest-client."claude-api".read-timeout=65000
+%test.quarkus.rest-client."claude-api".url=http://127.0.0.1:1
+%test.quarkus.rest-client."claude-api".connect-timeout=100
+%test.quarkus.rest-client."claude-api".read-timeout=100
 
 # Error Handling Configuration
 quarkus.log.category."com.dime.api.feature.shared.exception".level=DEBUG
@@ -76,6 +88,10 @@ quarkus.otel.exporter.otlp.protocol=grpc
 %dev.quarkus.otel.exporter.otlp.endpoint=
 %dev.quarkus.otel.logs.enabled=false
 %dev.quarkus.otel.traces.enabled=false
+%test.quarkus.otel.enabled=false
+%test.quarkus.otel.exporter.otlp.endpoint=
+%test.quarkus.otel.logs.enabled=false
+%test.quarkus.otel.traces.enabled=false
 
 quarkus.otel.resource.attributes=service.name=3dime-api,gcp.project_id=${GOOGLE_CLOUD_PROJECT:}
 
@@ -98,6 +114,7 @@ quarkus.log.category."io.quarkus.security".level=WARN
 %prod.quarkus.log.category."io.quarkus.vertx.http.runtime.security".level=WARN
 
 %test.quarkus.http.test-port=0
+%test.cache.warmup.enabled=false
 
 # Stripe Configuration
 stripe.api.key=${STRIPE_SECRET_KEY:}


### PR DESCRIPTION
Closes #210

## Summary

Adds the API pull-request CI path that the repository needs before making checks required on `main`.

This PR adds:

- A Java 21 `API CI` workflow for pull requests targeting `main`.
- Full Maven verification with `mvn -B -ntp clean verify`.
- A packaging gate that rebuilds the Quarkus uber-JAR and compares the sorted packaged-entry manifest across clean builds.
- Uploads for Surefire/Failsafe reports and failure diagnostics.
- Test-profile isolation from local `.env`, startup cache warmups, live REST-client URLs, and OpenTelemetry exporters.
- A scheduled `Security Scan` workflow for OWASP Dependency-Check and Trivy container findings.
- CI documentation covering local commands, required branch protection, and security-finding ownership/triage.

## Notes

The Quarkus uber-JAR currently is not byte-for-byte stable because generated Quarkus classes and ZIP entry ordering can vary between clean package runs. The CI gate therefore checks deterministic packaged contents by comparing the sorted JAR entry manifest while preserving the existing deployment contract around `target/3dime-api-runner.jar`.

OWASP Dependency-Check is moved behind the explicit `security-scan` Maven profile so normal PR verification is not dependent on live vulnerability feed availability.

## Validation

- `mvn -B -ntp clean verify`
  - `Tests run: 114, Failures: 0, Errors: 0, Skipped: 0`
- `mvn -B -ntp clean package -DskipTests`
- Local two-build package manifest comparison with `jar tf target/3dime-api-runner.jar | sort` and `diff`
- YAML parse for both new workflows
- `git diff --check`

## Follow-up After Merge

- Enable required branch protection for `main` with required check: `API CI / Java 21 tests and package`.
- Run one intentional failing-test PR/check to demonstrate merge blocking once the required check is active.
