### PR TITLE
[codex] Fix Firestore OpenTelemetry gRPC compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run -p 8080:8080 \
 
 ## 📚 Documentation
 
-[API Reference](docs/api.md), [Configuration](docs/configuration.md), [Architecture](docs/architecture.md), [Deployment](docs/deployment.md), [Health Monitoring](docs/health.md), [Security](docs/security.md), [CI](docs/ci.md)
+[API Reference](docs/api.md), [Configuration](docs/configuration.md), [Architecture](docs/architecture.md), [Deployment](docs/deployment.md), [Health Monitoring](docs/health.md), [Security](docs/security.md), [CI](docs/ci.md), [ADRs](docs/adr/0001-firestore-opentelemetry-grpc-compatibility.md)
 
 ---
 

--- a/docs/adr/0001-firestore-opentelemetry-grpc-compatibility.md
+++ b/docs/adr/0001-firestore-opentelemetry-grpc-compatibility.md
@@ -1,0 +1,41 @@
+# ADR 0001: Firestore and OpenTelemetry gRPC Compatibility
+
+## Status
+
+Accepted
+
+## Context
+
+`google-cloud-firestore` 3.38.0 constructs its traced gRPC client channel through
+`io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry.newClientInterceptor()`.
+
+Quarkus 3.36.2 manages newer OpenTelemetry instrumentation artifacts where
+`opentelemetry-grpc-1.6` 2.26+ exposes `createClientInterceptor()` instead. Forcing one of those
+newer gRPC instrumentation jars onto Firestore's runtime path causes a binary linkage failure:
+
+```text
+NoSuchMethodError: GrpcTelemetry.newClientInterceptor()
+```
+
+That failure was previously easy to miss because optional cache warmup and Firestore fallback code
+caught `Throwable`.
+
+## Decision
+
+Pin `io.opentelemetry.instrumentation:opentelemetry-grpc-1.6` to `2.1.0-alpha`, the version expected
+by the Google Cloud dependency set used by Firestore 3.38.0.
+
+Keep Quarkus-managed OpenTelemetry API and instrumentation API versions in place for the rest of the
+application. The pinned gRPC instrumentation jar is intentionally older because Firestore's bytecode
+calls the older public method name.
+
+Also treat `LinkageError` as unrecoverable. Firestore cache warmup and health checks may absorb
+normal runtime exceptions, but binary-incompatibility errors should fail loudly.
+
+## Consequences
+
+- Firestore tracing channel construction is covered by an automated compatibility test.
+- A future dependency bump that removes `newClientInterceptor()` fails tests before merge.
+- Optional cache warmup failures remain non-blocking for ordinary runtime exceptions.
+- Dependency upgrades should revisit this ADR and remove the pin only when Firestore is compiled
+  against the newer `createClientInterceptor()` API.

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
 
     <!-- Dependency Versions -->
     <quarkus-google-cloud-firestore.version>2.22.0</quarkus-google-cloud-firestore.version>
-    <!-- Firestore 3.x still calls GrpcTelemetry.newClientInterceptor(), renamed in 2.26+. -->
-    <opentelemetry-grpc.version>2.28.1-alpha</opentelemetry-grpc.version>
+    <!-- Firestore 3.38.0 calls GrpcTelemetry.newClientInterceptor(); 2.26+ renamed it. -->
+    <opentelemetry-grpc.version>2.1.0-alpha</opentelemetry-grpc.version>
     <opentelemetry-semconv.version>1.41.1</opentelemetry-semconv.version>
     <dotenv-java.version>3.2.0</dotenv-java.version>
     <lombok.version>1.18.46</lombok.version>

--- a/src/main/java/com/dime/api/feature/converter/QuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaService.java
@@ -114,7 +114,7 @@ public class QuotaService {
 
             return new QuotaCheckResult(allowed, remaining, limit, userQuota.getPlanType());
 
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.error("Error checking quota for user {}", userId, t);
             // Default allow on error to not block users
             return new QuotaCheckResult(true, -1, -1, DEFAULT_PLAN);
@@ -156,11 +156,11 @@ public class QuotaService {
                                 quota.email);
                     }
                 }
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 log.warn("Failed to sync to Notion for user {} (non-blocking)", userId, t);
             }
 
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.error("Error incrementing usage for user {}", userId, t);
         }
     }
@@ -175,7 +175,7 @@ public class QuotaService {
                 }
                 return userQuota;
             }
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.error("Error fetching quota status for {}", userId, t);
         }
         return null;
@@ -220,7 +220,7 @@ public class QuotaService {
                 DocumentSnapshot doc = result.getDocuments().get(0);
                 return new UserQuotaWrapper(doc.getId(), doc.toObject(UserQuota.class));
             }
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.error("Error searching user by email {}", email, t);
         }
         return null;
@@ -251,7 +251,7 @@ public class QuotaService {
                     .stream()
                     .map(doc -> new UserQuotaWrapper(doc.getId(), doc.toObject(UserQuota.class)))
                     .collect(Collectors.toList());
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.error("Error fetching all user quotas", t);
             return List.of();
         }
@@ -271,11 +271,11 @@ public class QuotaService {
                         quota.getPlanType(),
                         quota.periodStart != null ? quota.periodStart.toDate().toInstant() : Instant.now(),
                         quota.email);
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 log.warn("Failed to sync to Notion for user {} after update (non-blocking)", userId, t);
             }
 
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.error("Error updating quota for user {}", userId, t);
         }
     }
@@ -319,11 +319,11 @@ public class QuotaService {
                                 quota.email);
                     }
                 }
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 log.warn("Failed to sync plan update to Notion for user {} (non-blocking)", userId, t);
             }
 
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.error("Error updating plan for user {}", userId, t);
         }
     }
@@ -336,11 +336,11 @@ public class QuotaService {
             // Delete from Notion after deletion
             try {
                 notionQuotaService.deleteFromNotion(userId);
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 log.warn("Failed to delete from Notion for user {} (non-blocking)", userId, t);
             }
 
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.error("Error deleting quota for user {}", userId, t);
         }
     }
@@ -436,7 +436,7 @@ public class QuotaService {
             log.info("Synced user {} from Notion to Firestore", data.userId());
         } catch (InterruptedException | ExecutionException e) {
             log.error("Error updating user {} from Notion data", data.userId(), e);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.error("Unexpected error updating user {} from Notion data", data.userId(), t);
         }
     }

--- a/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
+++ b/src/main/java/com/dime/api/feature/shared/CacheWarmup.java
@@ -83,7 +83,7 @@ public class CacheWarmup {
     private void runWarmupStep(String stepName, Runnable task) {
         try {
             task.run();
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.warn("{} failed during startup warmup: {}", stepName, t.getMessage(), t);
         }
     }

--- a/src/main/java/com/dime/api/feature/shared/FirestoreCacheService.java
+++ b/src/main/java/com/dime/api/feature/shared/FirestoreCacheService.java
@@ -40,7 +40,7 @@ public class FirestoreCacheService {
                     return Optional.of(objectMapper.readValue(json, type));
                 }
             }
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.warn("Failed to read cache from Firestore for key: {}", key, t);
         }
         return Optional.empty();
@@ -55,7 +55,7 @@ public class FirestoreCacheService {
                     return Optional.of(objectMapper.readValue(json, type));
                 }
             }
-        } catch (Throwable t) {
+        } catch (Exception t) {
             log.warn("Failed to read cache from Firestore for key: {}", key, t);
         }
         return Optional.empty();
@@ -68,7 +68,7 @@ public class FirestoreCacheService {
                 firestore().collection(COLLECTION).document(key)
                         .set(Map.of("data", json, "updatedAt", Timestamp.now())).get(10, TimeUnit.SECONDS);
                 log.debug("Written cache to Firestore for key: {}", key);
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 log.warn("Failed to write cache to Firestore for key: {}", key, t);
             }
         });

--- a/src/main/java/com/dime/api/feature/shared/health/FirestoreHealthCheck.java
+++ b/src/main/java/com/dime/api/feature/shared/health/FirestoreHealthCheck.java
@@ -56,7 +56,7 @@ public class FirestoreHealthCheck implements HealthCheck {
                     .up()
                     .withData("latencyMs", latencyMs)
                     .build();
-        } catch (Throwable t) {
+        } catch (Exception t) {
             long latencyMs = System.currentTimeMillis() - start;
             log.warn("Firestore health check failed", t);
             return HealthCheckResponse.named(CHECK_NAME)

--- a/src/test/java/com/dime/api/feature/converter/QuotaServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/QuotaServiceTest.java
@@ -80,14 +80,10 @@ class QuotaServiceTest {
     }
 
     @Test
-    public void testCheckQuota_handlesLinkageErrorFromFirestoreBean() {
+    public void testCheckQuota_doesNotSwallowLinkageErrorFromFirestoreBean() {
         when(firestoreInstanceMock.get())
                 .thenThrow(new NoSuchMethodError("GrpcTelemetry.newClientInterceptor"));
 
-        assertDoesNotThrow(() -> {
-            QuotaService.QuotaCheckResult result = quotaService.checkQuota("linkage-error-user", null);
-            assertTrue(result.allowed());
-            assertEquals(PlanType.FREE, result.plan());
-        });
+        assertThrows(NoSuchMethodError.class, () -> quotaService.checkQuota("linkage-error-user", null));
     }
 }

--- a/src/test/java/com/dime/api/feature/shared/CacheWarmupTest.java
+++ b/src/test/java/com/dime/api/feature/shared/CacheWarmupTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -32,8 +33,8 @@ class CacheWarmupTest {
     }
 
     @Test
-    void runWarmupPhases_whenFirestoreWarmupThrowsError_doesNotAbortStartupSequence() {
-        doThrow(new NoSuchMethodError("io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry.newClientInterceptor()"))
+    void runWarmupPhases_whenFirestoreWarmupThrowsRecoverableError_doesNotAbortStartupSequence() {
+        doThrow(new RuntimeException("Firestore unavailable"))
                 .when(gitHubService).warmFromFirestore();
 
         assertDoesNotThrow(() -> cacheWarmup.runWarmupPhases());
@@ -45,8 +46,16 @@ class CacheWarmupTest {
     }
 
     @Test
+    void runWarmupPhases_whenFirestoreWarmupThrowsLinkageError_propagates() {
+        doThrow(new NoSuchMethodError("io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry.newClientInterceptor()"))
+                .when(gitHubService).warmFromFirestore();
+
+        assertThrows(NoSuchMethodError.class, () -> cacheWarmup.runWarmupPhases());
+    }
+
+    @Test
     void warmFromApis_whenOneWarmupStepThrowsError_continuesRemainingSteps() {
-        doThrow(new NoSuchMethodError("boom"))
+        doThrow(new RuntimeException("boom"))
                 .when(gitHubService).getUserInfo();
 
         assertDoesNotThrow(() -> cacheWarmup.warmFromApis());
@@ -59,4 +68,3 @@ class CacheWarmupTest {
         verify(trackingService, times(1)).getStatistics();
     }
 }
-

--- a/src/test/java/com/dime/api/feature/shared/FirestoreCompatibilityTest.java
+++ b/src/test/java/com/dime/api/feature/shared/FirestoreCompatibilityTest.java
@@ -2,10 +2,18 @@ package com.dime.api.feature.shared;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.api.core.ApiFunction;
 import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOpenTelemetryOptions;
 import com.google.cloud.firestore.FirestoreOptions;
+import io.grpc.ManagedChannelBuilder;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -15,17 +23,50 @@ class FirestoreCompatibilityTest {
 
     @Test
     void firestoreServiceCreation_doesNotThrowTelemetryLinkageError() {
+        FirestoreOptions options = firestoreOptionsWithOpenTelemetry();
+
         assertDoesNotThrow(() -> {
-            try (Firestore firestore = FirestoreOptions.newBuilder()
-                    .setProjectId("test-project")
-                    .setCredentials(GoogleCredentials.create(
-                            new AccessToken("test-token", new Date(Long.MAX_VALUE))))
-                    .build()
-                    .getService()) {
+            try (Firestore firestore = options.getService()) {
                 assertNotNull(firestore);
             }
         });
     }
+
+    @Test
+    void firestoreGrpcTelemetryApi_matchesFirestoreBytecode() {
+        assertDoesNotThrow(() -> GrpcTelemetry.class.getMethod("newClientInterceptor"));
+    }
+
+    @Test
+    void firestoreOpenTelemetryChannelConfigurator_doesNotThrowLinkageError() {
+        FirestoreOptions options = firestoreOptionsWithOpenTelemetry();
+
+        assertDoesNotThrow(() -> {
+            Class<?> traceUtilClass = Class.forName("com.google.cloud.firestore.telemetry.EnabledTraceUtil");
+            Constructor<?> constructor = traceUtilClass.getDeclaredConstructor(FirestoreOptions.class);
+            constructor.setAccessible(true);
+            Object traceUtil = constructor.newInstance(options);
+
+            Method getChannelConfigurator = traceUtilClass.getDeclaredMethod("getChannelConfigurator");
+            @SuppressWarnings("unchecked")
+            ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> configurator =
+                    (ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>) getChannelConfigurator.invoke(traceUtil);
+
+            ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forTarget("localhost:1").usePlaintext();
+            assertNotNull(configurator.apply(channelBuilder));
+        });
+    }
+
+    private FirestoreOptions firestoreOptionsWithOpenTelemetry() {
+        FirestoreOpenTelemetryOptions openTelemetryOptions = FirestoreOpenTelemetryOptions.newBuilder()
+                .setOpenTelemetry(OpenTelemetrySdk.builder().build())
+                .build();
+
+        return FirestoreOptions.newBuilder()
+                .setProjectId("test-project")
+                .setCredentials(GoogleCredentials.create(
+                        new AccessToken("test-token", new Date(Long.MAX_VALUE))))
+                .setOpenTelemetryOptions(openTelemetryOptions)
+                .build();
+    }
 }
-
-

--- a/src/test/java/com/dime/api/feature/shared/health/FirestoreHealthCheckTest.java
+++ b/src/test/java/com/dime/api/feature/shared/health/FirestoreHealthCheckTest.java
@@ -84,14 +84,10 @@ class FirestoreHealthCheckTest {
     }
 
     @Test
-    void testDown_onLinkageErrorDuringBeanInitialization() {
+    void testLinkageErrorDuringBeanInitialization_isNotSwallowed() {
         when(firestoreInstanceMock.get()).thenThrow(new NoSuchMethodError("GrpcTelemetry.newClientInterceptor"));
 
-        HealthCheckResponse response = check.doCheck();
-
-        assertEquals(HealthCheckResponse.Status.DOWN, response.getStatus());
-        assertTrue(response.getData().isPresent());
-        assertNotNull(response.getData().get().get("error"));
+        assertThrows(NoSuchMethodError.class, () -> check.doCheck());
     }
 
     @Test


### PR DESCRIPTION
Closes #211

## Summary
- Pin `io.opentelemetry.instrumentation:opentelemetry-grpc-1.6` to `2.1.0-alpha`, matching the API Firestore 3.38.0 calls at runtime (`GrpcTelemetry.newClientInterceptor`).
- Stop swallowing `LinkageError` in Firestore-adjacent cache, warmup, health, and quota paths while keeping ordinary runtime failures non-blocking where intended.
- Add a compatibility test that invokes Firestore's OpenTelemetry channel configurator so dependency drift fails before deploy.
- Document the compatibility decision in `docs/adr/0001-firestore-opentelemetry-grpc-compatibility.md`.

## Validation
- `mvn -B -ntp dependency:tree -Dincludes=io.opentelemetry.instrumentation:opentelemetry-grpc-1.6,io.opentelemetry.instrumentation:opentelemetry-instrumentation-api,com.google.cloud:google-cloud-firestore -Dverbose`
- `mvn -B -ntp -Dtest=FirestoreCompatibilityTest,FirestoreHealthCheckTest,CacheWarmupTest,QuotaServiceTest test` (19 tests passed)
- `mvn -B -ntp clean verify` (117 tests passed, build/package succeeded)
- Report scan found only intentional test names for `NoSuchMethodError`/`LinkageError`, not runtime stack traces.

## Notes
- Existing test-profile connection-refused warnings against `127.0.0.1:1` are expected live-client isolation behavior.
- Existing Quarkus logging JSON config warnings are outside this ticket.
