### PR TITLE
[codex] Fix Firestore telemetry completion linkage

### DIFF
--- a/docs/adr/0001-firestore-opentelemetry-grpc-compatibility.md
+++ b/docs/adr/0001-firestore-opentelemetry-grpc-compatibility.md
@@ -17,24 +17,33 @@ newer gRPC instrumentation jars onto Firestore's runtime path causes a binary li
 NoSuchMethodError: GrpcTelemetry.newClientInterceptor()
 ```
 
+The initially selected `2.1.0-alpha` release has a second incompatibility: its completion callback
+references the removed `io.opentelemetry.semconv.SemanticAttributes` class. Modern semconv releases
+therefore fail after a Firestore call completes:
+
+```text
+NoClassDefFoundError: io/opentelemetry/semconv/SemanticAttributes
+```
+
 That failure was previously easy to miss because optional cache warmup and Firestore fallback code
 caught `Throwable`.
 
 ## Decision
 
-Pin `io.opentelemetry.instrumentation:opentelemetry-grpc-1.6` to `2.1.0-alpha`, the version expected
-by the Google Cloud dependency set used by Firestore 3.38.0.
+Pin `io.opentelemetry.instrumentation:opentelemetry-grpc-1.6` to `2.23.0-alpha`. This is within the
+compatibility window where `newClientInterceptor()` still exists and the completion extractor no
+longer references the removed monolithic semantic attributes class.
 
 Keep Quarkus-managed OpenTelemetry API and instrumentation API versions in place for the rest of the
-application. The pinned gRPC instrumentation jar is intentionally older because Firestore's bytecode
-calls the older public method name.
+application, including semconv. The pinned gRPC instrumentation jar is intentionally older because
+Firestore's bytecode calls the older public method name.
 
 Also treat `LinkageError` as unrecoverable. Firestore cache warmup and health checks may absorb
 normal runtime exceptions, but binary-incompatibility errors should fail loudly.
 
 ## Consequences
 
-- Firestore tracing channel construction is covered by an automated compatibility test.
+- Firestore tracing channel construction and completion are covered by automated compatibility tests.
 - A future dependency bump that removes `newClientInterceptor()` fails tests before merge.
 - Optional cache warmup failures remain non-blocking for ordinary runtime exceptions.
 - Dependency upgrades should revisit this ADR and remove the pin only when Firestore is compiled

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,8 @@
 
     <!-- Dependency Versions -->
     <quarkus-google-cloud-firestore.version>2.22.0</quarkus-google-cloud-firestore.version>
-    <!-- Firestore 3.38.0 calls GrpcTelemetry.newClientInterceptor(); 2.26+ renamed it. -->
-    <opentelemetry-grpc.version>2.1.0-alpha</opentelemetry-grpc.version>
-    <opentelemetry-semconv.version>1.42.0</opentelemetry-semconv.version>
+    <!-- Firestore 3.38.0 needs newClientInterceptor(); 2.26+ renamed it, while older 2.1 uses removed semconv APIs. -->
+    <opentelemetry-grpc.version>2.23.0-alpha</opentelemetry-grpc.version>
     <dotenv-java.version>3.2.0</dotenv-java.version>
     <lombok.version>1.18.46</lombok.version>
   </properties>
@@ -177,11 +176,6 @@
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-grpc-1.6</artifactId>
       <version>${opentelemetry-grpc.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.opentelemetry.semconv</groupId>
-      <artifactId>opentelemetry-semconv</artifactId>
-      <version>${opentelemetry-semconv.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/test/java/com/dime/api/feature/shared/FirestoreCompatibilityTest.java
+++ b/src/test/java/com/dime/api/feature/shared/FirestoreCompatibilityTest.java
@@ -7,14 +7,20 @@ import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOpenTelemetryOptions;
 import com.google.cloud.firestore.FirestoreOptions;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -35,6 +41,30 @@ class FirestoreCompatibilityTest {
     @Test
     void firestoreGrpcTelemetryApi_matchesFirestoreBytecode() {
         assertDoesNotThrow(() -> GrpcTelemetry.class.getMethod("newClientInterceptor"));
+    }
+
+    @Test
+    void firestoreGrpcTelemetryCompletion_doesNotThrowSemconvLinkageError() {
+        assertDoesNotThrow(() -> {
+            Class<?> getterClass = Class.forName(
+                    "io.opentelemetry.instrumentation.grpc.v1_6.GrpcRpcAttributesGetter");
+            Field instanceField = getterClass.getDeclaredField("INSTANCE");
+            instanceField.setAccessible(true);
+
+            Class<?> extractorClass = Class.forName(
+                    "io.opentelemetry.instrumentation.grpc.v1_6.GrpcAttributesExtractor");
+            Constructor<?> constructor = extractorClass.getDeclaredConstructor(getterClass, List.class);
+            constructor.setAccessible(true);
+            Object extractor = constructor.newInstance(instanceField.get(null), List.of());
+
+            Class<?> requestClass = Class.forName(
+                    "io.opentelemetry.instrumentation.grpc.v1_6.GrpcRequest");
+            Method onEnd = extractorClass.getDeclaredMethod("onEnd", AttributesBuilder.class,
+                    Context.class, requestClass, Status.class, Throwable.class);
+            onEnd.setAccessible(true);
+
+            onEnd.invoke(extractor, Attributes.builder(), Context.root(), null, Status.OK, null);
+        });
     }
 
     @Test


### PR DESCRIPTION
## Summary

- move `opentelemetry-grpc-1.6` from `2.1.0-alpha` to the compatible `2.23.0-alpha` release
- remove the independent semconv override and use the Quarkus BOM-managed version
- exercise the gRPC telemetry completion extractor in the Firestore compatibility suite
- update ADR 0001 with both linkage constraints

## Root cause

Firestore 3.38.0 requires `GrpcTelemetry.newClientInterceptor()`, which is unavailable in OpenTelemetry gRPC instrumentation 2.26+. The earlier fix pinned 2.1.0-alpha, but that release still references the removed `io.opentelemetry.semconv.SemanticAttributes` class from its `onEnd` callback. Firestore requests therefore crashed after gRPC completion and surfaced as `DATASTORE_UNAVAILABLE` / HTTP 503.

Version 2.23.0-alpha is inside the required compatibility window: it retains `newClientInterceptor()` and no longer links against the removed monolithic semantic attributes class.

## Validation

- regression test reproduced `NoClassDefFoundError` before the dependency change
- `mvn -B -ntp -Dtest=FirestoreCompatibilityTest test` passes (4 tests)
- `mvn -B -ntp clean verify` passes (124 tests and uber-jar packaging)
- resolved classpath uses gRPC instrumentation 2.23.0-alpha and Quarkus-managed semconv 1.40.0

## Impact

Firestore quota reservations can complete locally and in production without crashing the gRPC telemetry callback, removing the secondary 503 response from converter requests.
