### PR TITLE
Protect free quota across account changes

### DIFF
--- a/contracts/openapi-v1.json
+++ b/contracts/openapi-v1.json
@@ -349,6 +349,13 @@
         "summary" : "Convert images to calendar events",
         "description" : "Uses AI to extract calendar events from images and convert them to ICS format",
         "tags" : [ "converter" ],
+        "parameters" : [ {
+          "name" : "X-Installation-ID",
+          "in" : "header",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -372,6 +379,16 @@
           },
           "400" : {
             "description" : "Invalid request data",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Verified Google authentication required",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -487,6 +504,12 @@
             "type" : "string"
           },
           "required" : true
+        }, {
+          "name" : "X-Installation-ID",
+          "in" : "header",
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "200" : {
@@ -495,6 +518,16 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/QuotaStatusResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Verified Google authentication required",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,7 +168,7 @@ header; otherwise the API generates one. User-facing behavior must use `errorCod
 | `401` | `AUTHENTICATION_REQUIRED` | Authentication is required |
 | `409` | `IDEMPOTENCY_CONFLICT` | The idempotency key is already in progress |
 | `422` | `PROCESSING_ERROR` | Valid input but processing failed |
-| `429` | `QUOTA_EXCEEDED` | Monthly conversion limit reached |
+| `429` | `QUOTA_EXCEEDED` | Account, installation, shared-network, or service-capacity allowance reached |
 | `429` | `RATE_LIMIT_EXCEEDED` | Endpoint rate limit reached |
 | `502` | `EXTERNAL_SERVICE_ERROR` | Upstream API failure (Gemini, Notion, GitHub) |
 | `503` | `DATASTORE_UNAVAILABLE` | Quota reservation cannot be guaranteed |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,11 @@ The `.env` file is loaded via `dotenv-java` through `DotEnvConfigSource`. It is 
 | `GEMINI_SYSTEM_PROMPT` | *(empty)* | System-level Gemini prompt |
 | `PORT` | `8080` | HTTP server port |
 | `GOOGLE_CLOUD_PROJECT` | *(empty)* | GCP project ID for telemetry |
+| `QUOTA_IDENTITY_PEPPER` | `AUTH_SESSION_ENCRYPTION_KEY` | HMAC secret for pseudonymized quota identities; set a dedicated production secret when possible |
+| `QUOTA_FREE_DEVICE_LIMIT` | `3` | Monthly free conversions shared by one browser installation |
+| `QUOTA_FREE_NETWORK_DAILY_LIMIT` | `12` | Daily free-conversion threshold for the shared-network safeguard |
+| `QUOTA_FREE_NETWORK_ACCOUNT_THRESHOLD` | `3` | Distinct accounts required before the network safeguard blocks |
+| `QUOTA_FREE_GLOBAL_DAILY_LIMIT` | `500` | Daily free-conversion safety ceiling for AI spend |
 
 ---
 
@@ -70,3 +75,6 @@ Quarkus profile prefixes scope configuration to specific environments:
 | Dev (`%dev`) | `*` (all origins) |
 
 Allowed methods: `GET, PUT, POST, DELETE, PATCH, OPTIONS` | Max age: 24 hours
+
+The converter accepts `X-Installation-ID`. Current web clients send a stable random identifier;
+Firestore receives only HMAC-derived document identifiers, never the raw header or raw IP address.

--- a/src/main/java/com/dime/api/feature/converter/ConverterResource.java
+++ b/src/main/java/com/dime/api/feature/converter/ConverterResource.java
@@ -4,6 +4,7 @@ import com.dime.api.feature.shared.exception.ProcessingException;
 import com.dime.api.feature.shared.exception.QuotaException;
 import com.dime.api.feature.shared.exception.ValidationException;
 import com.dime.api.feature.shared.exception.IdempotencyException;
+import com.dime.api.feature.shared.exception.AuthenticationException;
 import com.dime.api.feature.shared.exception.ErrorResponse;
 import com.dime.api.feature.shared.config.FirebaseAuthFilter;
 import jakarta.inject.Inject;
@@ -45,6 +46,9 @@ public class ConverterResource {
     QuotaService quotaService;
 
     @Inject
+    QuotaIdentityService quotaIdentityService;
+
+    @Inject
     GeminiService geminiService;
 
     @Inject
@@ -63,6 +67,7 @@ public class ConverterResource {
     @Operation(summary = "Convert images to calendar events", description = "Uses AI to extract calendar events from images and convert them to ICS format")
     @APIResponse(responseCode = "200", description = "Conversion successful", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConverterResponse.class)))
     @APIResponse(responseCode = "400", description = "Invalid request data", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
+    @APIResponse(responseCode = "401", description = "Verified Google authentication required", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
     @APIResponse(responseCode = "409", description = "Idempotency conflict", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
     @APIResponse(responseCode = "422", description = "Processing error - valid input but conversion failed", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
     @APIResponse(responseCode = "429", description = "Quota or rate limit exceeded", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
@@ -70,14 +75,21 @@ public class ConverterResource {
     @APIResponse(responseCode = "503", description = "Quota datastore unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
     @APIResponse(responseCode = "504", description = "AI provider timed out", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
     @APIResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
-    public Response convert(@Valid @NotNull ConverterRequest request, @Context HttpHeaders headers,
+    public Response convert(@Valid @NotNull ConverterRequest request,
+            @HeaderParam("X-Installation-ID") String installationId, @Context HttpHeaders headers,
             @Context ContainerRequestContext requestContext) {
         long startTime = System.currentTimeMillis();
         String verifiedUid = (String) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_UID);
+        Boolean emailVerified = (Boolean) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_EMAIL_VERIFIED);
+        if (verifiedUid == null || !Boolean.TRUE.equals(emailVerified)) {
+            throw new AuthenticationException("A verified Google account is required to convert files.");
+        }
         String rawEmail = (String) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_EMAIL);
         String email = rawEmail != null && rawEmail.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
                 ? rawEmail : null;
-        String userId = verifiedUid != null ? verifiedUid : "anonymous";
+        String userId = verifiedUid;
+        QuotaIdentityService.QuotaIdentity quotaIdentity = quotaIdentityService.resolve(
+                userId, installationId, requestContext);
         String domain = getDomain(headers);
         int fileCount = request.files != null ? request.files.size() : 0;
 
@@ -104,7 +116,7 @@ public class ConverterResource {
         String idempotencyKey = headers.getHeaderString("Idempotency-Key");
         QuotaService.QuotaReservationResult reservation;
         try {
-            reservation = quotaService.reserveQuota(userId, email, idempotencyKey, fileCount);
+            reservation = quotaService.reserveQuota(userId, email, idempotencyKey, fileCount, quotaIdentity);
         } catch (QuotaException e) {
             logQuotaExceeded(userId, email, domain, e);
             throw e;
@@ -171,16 +183,24 @@ public class ConverterResource {
     @RateLimit(value = 30, window = 1, windowUnit = ChronoUnit.MINUTES)
     @Operation(summary = "Get user quota status", description = "Retrieves the current quota usage and plan information for a user")
     @APIResponse(responseCode = "200", description = "Quota status retrieved successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = QuotaStatusResponse.class)))
+    @APIResponse(responseCode = "401", description = "Verified Google authentication required", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
     @APIResponse(responseCode = "404", description = "User not found")
     @APIResponse(responseCode = "500", description = "Internal server error")
     public Response getQuotaStatus(@QueryParam("userId") @NotNull String userId,
+            @HeaderParam("X-Installation-ID") String installationId,
             @Context ContainerRequestContext requestContext) {
         String verifiedUid = (String) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_UID);
-        String effectiveUserId = verifiedUid != null ? verifiedUid : userId;
+        Boolean emailVerified = (Boolean) requestContext.getProperty(FirebaseAuthFilter.FIREBASE_EMAIL_VERIFIED);
+        if (verifiedUid == null || !Boolean.TRUE.equals(emailVerified)) {
+            throw new AuthenticationException("A verified Google account is required to view quota status.");
+        }
+        String effectiveUserId = verifiedUid;
+        QuotaIdentityService.QuotaIdentity quotaIdentity = quotaIdentityService.resolve(
+                effectiveUserId, installationId, requestContext);
         log.info("GET /converter/quotaStatus endpoint called for user: {}", effectiveUserId);
 
         try {
-            UserQuota userQuota = quotaService.getQuotaStatus(effectiveUserId);
+            UserQuota userQuota = quotaService.getQuotaStatus(effectiveUserId, quotaIdentity);
 
             if (userQuota == null) {
                 return Response.status(Response.Status.NOT_FOUND)

--- a/src/main/java/com/dime/api/feature/converter/QuotaIdentityService.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaIdentityService.java
@@ -1,0 +1,63 @@
+package com.dime.api.feature.converter;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class QuotaIdentityService {
+
+    private static final Pattern INSTALLATION_ID = Pattern.compile("[A-Za-z0-9_-]{20,128}");
+
+    @ConfigProperty(name = "quota.identity.pepper", defaultValue = "photocalia-local-only")
+    String pepper;
+
+    public record QuotaIdentity(String deviceHash, String networkHash, String accountHash) {
+    }
+
+    public QuotaIdentity resolve(String userId, String installationId, ContainerRequestContext requestContext) {
+        String normalizedInstallation = normalizeInstallationId(installationId, userId);
+        String clientNetwork = clientNetwork(requestContext);
+        return new QuotaIdentity(
+                hash("device", normalizedInstallation),
+                clientNetwork != null ? hash("network", clientNetwork) : null,
+                hash("account", userId));
+    }
+
+    String normalizeInstallationId(String installationId, String userId) {
+        if (installationId != null) {
+            String normalized = installationId.trim();
+            if (INSTALLATION_ID.matcher(normalized).matches()) {
+                return normalized;
+            }
+        }
+        return "legacy:" + userId;
+    }
+
+    String clientNetwork(ContainerRequestContext requestContext) {
+        String forwardedFor = requestContext.getHeaderString("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            String first = forwardedFor.split(",", 2)[0].trim();
+            return first.isBlank() ? null : first;
+        }
+        String realIp = requestContext.getHeaderString("X-Real-IP");
+        return realIp == null || realIp.isBlank() ? null : realIp.trim();
+    }
+
+    String hash(String namespace, String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(pepper.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(
+                    mac.doFinal((namespace + ':' + value).getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to derive quota identity", e);
+        }
+    }
+}

--- a/src/main/java/com/dime/api/feature/converter/QuotaReservation.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaReservation.java
@@ -22,6 +22,10 @@ public class QuotaReservation {
     public String provider;
     public String failureReason;
     public String icsContent;
+    public String deviceHash;
+    public String networkHash;
+    public String globalCounterId;
+    public boolean freeProtectionApplied;
     public Timestamp periodStart;
     public Timestamp reservedAt;
     public Timestamp completedAt;

--- a/src/main/java/com/dime/api/feature/converter/QuotaService.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaService.java
@@ -14,12 +14,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Comparator;
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -33,6 +37,9 @@ public class QuotaService {
 
     private static final String COLLECTION_NAME = "users";
     private static final String RESERVATIONS_COLLECTION = "quotaReservations";
+    private static final String DEVICE_COLLECTION = "quotaDevices";
+    private static final String NETWORK_COLLECTION = "quotaNetworks";
+    private static final String GLOBAL_COLLECTION = "quotaGlobal";
     private static final PlanType DEFAULT_PLAN = PlanType.FREE;
 
     @ConfigProperty(name = "quota.limit.free", defaultValue = "3")
@@ -49,6 +56,18 @@ public class QuotaService {
 
     @ConfigProperty(name = "quota.reservation.ttl-minutes", defaultValue = "15")
     long reservationTtlMinutes;
+
+    @ConfigProperty(name = "quota.free.device-limit", defaultValue = "3")
+    long freeDeviceLimit;
+
+    @ConfigProperty(name = "quota.free.network-daily-limit", defaultValue = "12")
+    long freeNetworkDailyLimit;
+
+    @ConfigProperty(name = "quota.free.network-account-threshold", defaultValue = "3")
+    int freeNetworkAccountThreshold;
+
+    @ConfigProperty(name = "quota.free.global-daily-limit", defaultValue = "500")
+    long freeGlobalDailyLimit;
 
     private volatile Map<PlanType, Long> quotaLimits;
 
@@ -139,6 +158,11 @@ public class QuotaService {
 
     public QuotaReservationResult reserveQuota(@NonNull String userId, String email,
             String idempotencyKey, int fileCount) {
+        return reserveQuota(userId, email, idempotencyKey, fileCount, null);
+    }
+
+    public QuotaReservationResult reserveQuota(@NonNull String userId, String email,
+            String idempotencyKey, int fileCount, QuotaIdentityService.QuotaIdentity identity) {
         if (idempotencyKey == null || idempotencyKey.isBlank()) {
             throw new ValidationException("Idempotency-Key header is required for conversion requests.");
         }
@@ -147,6 +171,16 @@ public class QuotaService {
         try {
             DocumentReference docRef = firestore().collection(COLLECTION_NAME).document(userId);
             DocumentReference reservationRef = docRef.collection(RESERVATIONS_COLLECTION).document(normalizedKey);
+            DocumentReference deviceRef = identity != null
+                    ? firestore().collection(DEVICE_COLLECTION).document(identity.deviceHash())
+                    : null;
+            DocumentReference networkRef = identity != null && identity.networkHash() != null
+                    ? firestore().collection(NETWORK_COLLECTION).document(identity.networkHash())
+                    : null;
+            String globalCounterId = LocalDate.now(ZoneOffset.UTC).toString();
+            DocumentReference globalRef = identity != null
+                    ? firestore().collection(GLOBAL_COLLECTION).document(globalCounterId)
+                    : null;
 
             QuotaReservationResult result = firestore().runTransaction(transaction -> {
                 Timestamp now = Timestamp.now();
@@ -194,6 +228,35 @@ public class QuotaService {
                             Map.of("limit", limit, "remaining", 0, "plan", plan));
                 }
 
+                QuotaSubject deviceSubject = null;
+                QuotaSubject networkSubject = null;
+                QuotaSubject globalSubject = null;
+                if (plan == PlanType.FREE && identity != null) {
+                    DocumentSnapshot deviceSnapshot = transaction.get(deviceRef).get();
+                    deviceSubject = monthlySubject(deviceSnapshot, "DEVICE", freeDeviceLimit, now);
+                    if (deviceSubject.usageCount >= freeDeviceLimit) {
+                        throw protectionQuotaException(limit, plan, "device");
+                    }
+
+                    if (networkRef != null) {
+                        DocumentSnapshot networkSnapshot = transaction.get(networkRef).get();
+                        networkSubject = dailySubject(networkSnapshot, "NETWORK", freeNetworkDailyLimit, now);
+                        HashSet<String> accounts = new HashSet<>(networkSubject.accountHashes);
+                        accounts.add(identity.accountHash());
+                        if (networkSubject.usageCount >= freeNetworkDailyLimit
+                                && accounts.size() >= freeNetworkAccountThreshold) {
+                            throw protectionQuotaException(limit, plan, "network");
+                        }
+                        networkSubject.accountHashes = new ArrayList<>(accounts);
+                    }
+
+                    DocumentSnapshot globalSnapshot = transaction.get(globalRef).get();
+                    globalSubject = dailySubject(globalSnapshot, "GLOBAL", freeGlobalDailyLimit, now);
+                    if (globalSubject.usageCount >= freeGlobalDailyLimit) {
+                        throw protectionQuotaException(limit, plan, "service_capacity");
+                    }
+                }
+
                 long usedAfterReservation = userQuota.quotaUsed + 1;
                 Map<String, Object> quotaUpdates = new HashMap<>();
                 quotaUpdates.put("plan", plan.name());
@@ -219,8 +282,26 @@ public class QuotaService {
                 reservation.reservedAt = now;
                 reservation.expiresAt = expiresAt;
                 reservation.updatedAt = now;
+                reservation.freeProtectionApplied = plan == PlanType.FREE && identity != null;
+                if (reservation.freeProtectionApplied) {
+                    reservation.deviceHash = identity.deviceHash();
+                    reservation.networkHash = identity.networkHash();
+                    reservation.globalCounterId = globalCounterId;
+                }
 
                 transaction.set(docRef, quotaUpdates, SetOptions.merge());
+                if (deviceSubject != null) {
+                    incrementSubject(deviceSubject, now);
+                    transaction.set(deviceRef, deviceSubject);
+                }
+                if (networkSubject != null) {
+                    incrementSubject(networkSubject, now);
+                    transaction.set(networkRef, networkSubject);
+                }
+                if (globalSubject != null) {
+                    incrementSubject(globalSubject, now);
+                    transaction.set(globalRef, globalSubject);
+                }
                 transaction.set(reservationRef, reservation);
 
                 long remaining = Math.max(0, limit - usedAfterReservation);
@@ -307,6 +388,14 @@ public class QuotaService {
                     return null;
                 }
 
+                Map<DocumentReference, DocumentSnapshot> protectionSnapshots = new HashMap<>();
+                if (refund && currentState == QuotaReservationState.RESERVED
+                        && reservation.freeProtectionApplied) {
+                    for (DocumentReference protectionRef : protectionReferences(reservation)) {
+                        protectionSnapshots.put(protectionRef, transaction.get(protectionRef).get());
+                    }
+                }
+
                 Map<String, Object> reservationUpdates = new HashMap<>();
                 reservationUpdates.put("state", targetState.name());
                 reservationUpdates.put("provider", provider);
@@ -327,6 +416,9 @@ public class QuotaService {
                                 "quotaUsed", Math.max(0, userQuota.quotaUsed - 1),
                                 "updatedAt", now));
                     }
+                }
+                if (!protectionSnapshots.isEmpty()) {
+                    refundProtectionCounters(transaction, protectionSnapshots, now);
                 }
 
                 transaction.update(reservationRef, reservationUpdates);
@@ -361,6 +453,14 @@ public class QuotaService {
                 return null;
             }
 
+
+            Map<DocumentReference, DocumentSnapshot> protectionSnapshots = new HashMap<>();
+            if (reservation.freeProtectionApplied) {
+                for (DocumentReference protectionRef : protectionReferences(reservation)) {
+                    protectionSnapshots.put(protectionRef, transaction.get(protectionRef).get());
+                }
+            }
+
             if (userSnapshot.exists()) {
                 UserQuota userQuota = userSnapshot.toObject(UserQuota.class);
                 if (userQuota != null) {
@@ -368,6 +468,9 @@ public class QuotaService {
                             "quotaUsed", Math.max(0, userQuota.quotaUsed - 1),
                             "updatedAt", now));
                 }
+            }
+            if (!protectionSnapshots.isEmpty()) {
+                refundProtectionCounters(transaction, protectionSnapshots, now);
             }
 
             transaction.update(reservationRef, Map.of(
@@ -457,6 +560,10 @@ public class QuotaService {
     }
 
     public UserQuota getQuotaStatus(@NonNull String userId) {
+        return getQuotaStatus(userId, null);
+    }
+
+    public UserQuota getQuotaStatus(@NonNull String userId, QuotaIdentityService.QuotaIdentity identity) {
         try {
             DocumentSnapshot document = firestore().collection(COLLECTION_NAME).document(userId).get().get(5, TimeUnit.SECONDS);
             if (document.exists()) {
@@ -464,12 +571,51 @@ public class QuotaService {
                 if (userQuota != null && isNewMonth(userQuota.periodStart)) {
                     userQuota.quotaUsed = 0; // Virtual reset for display
                 }
+                if (userQuota != null && userQuota.getPlanType() == PlanType.FREE && identity != null) {
+                    applyProtectionStatus(userQuota, identity);
+                }
                 return userQuota;
+            }
+            if (identity != null) {
+                Timestamp now = Timestamp.now();
+                UserQuota newUserQuota = new UserQuota(
+                        DEFAULT_PLAN, 0, quotaLimits.get(DEFAULT_PLAN), now, now, now);
+                applyProtectionStatus(newUserQuota, identity);
+                return newUserQuota;
             }
         } catch (Exception t) {
             log.error("Error fetching quota status for {}", userId, t);
         }
         return null;
+    }
+
+    private void applyProtectionStatus(UserQuota userQuota, QuotaIdentityService.QuotaIdentity identity)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        long effectiveLimit = Math.min(quotaLimits.getOrDefault(PlanType.FREE, quotaLimitFree), freeDeviceLimit);
+        DocumentSnapshot deviceSnapshot = firestore().collection(DEVICE_COLLECTION)
+                .document(identity.deviceHash()).get().get(5, TimeUnit.SECONDS);
+        QuotaSubject device = monthlySubject(deviceSnapshot, "DEVICE", freeDeviceLimit, Timestamp.now());
+        long effectiveUsed = Math.max(userQuota.quotaUsed, device.usageCount);
+
+        boolean restricted = false;
+        if (identity.networkHash() != null) {
+            DocumentSnapshot networkSnapshot = firestore().collection(NETWORK_COLLECTION)
+                    .document(identity.networkHash()).get().get(5, TimeUnit.SECONDS);
+            QuotaSubject network = dailySubject(networkSnapshot, "NETWORK", freeNetworkDailyLimit, Timestamp.now());
+            HashSet<String> accounts = new HashSet<>(network.accountHashes);
+            accounts.add(identity.accountHash());
+            restricted = network.usageCount >= freeNetworkDailyLimit
+                    && accounts.size() >= freeNetworkAccountThreshold;
+        }
+
+        String globalCounterId = LocalDate.now(ZoneOffset.UTC).toString();
+        DocumentSnapshot globalSnapshot = firestore().collection(GLOBAL_COLLECTION)
+                .document(globalCounterId).get().get(5, TimeUnit.SECONDS);
+        QuotaSubject global = dailySubject(globalSnapshot, "GLOBAL", freeGlobalDailyLimit, Timestamp.now());
+        restricted = restricted || global.usageCount >= freeGlobalDailyLimit;
+
+        userQuota.quotaLimit = effectiveLimit;
+        userQuota.quotaUsed = restricted ? effectiveLimit : Math.min(effectiveLimit, effectiveUsed);
     }
 
     private UserQuota createUser(@NonNull String userId, String email) throws ExecutionException, InterruptedException, TimeoutException {
@@ -543,6 +689,80 @@ public class QuotaService {
 
     private Timestamp timestampFromInstant(Instant instant) {
         return Timestamp.ofTimeSecondsAndNanos(instant.getEpochSecond(), instant.getNano());
+    }
+
+    private QuotaSubject monthlySubject(DocumentSnapshot snapshot, String type, long limit, Timestamp now) {
+        QuotaSubject subject = snapshot.exists() ? snapshot.toObject(QuotaSubject.class) : null;
+        if (subject == null || isNewMonth(subject.periodStart)) {
+            subject = newSubject(type, limit, now, Instant.now().plus(62, ChronoUnit.DAYS));
+        }
+        subject.quotaLimit = limit;
+        return subject;
+    }
+
+    private QuotaSubject dailySubject(DocumentSnapshot snapshot, String type, long limit, Timestamp now) {
+        QuotaSubject subject = snapshot.exists() ? snapshot.toObject(QuotaSubject.class) : null;
+        if (subject == null || !isSameUtcDay(subject.periodStart, now)) {
+            subject = newSubject(type, limit, now, Instant.now().plus(3, ChronoUnit.DAYS));
+        }
+        subject.quotaLimit = limit;
+        return subject;
+    }
+
+    private QuotaSubject newSubject(String type, long limit, Timestamp now, Instant expiresAt) {
+        QuotaSubject subject = new QuotaSubject();
+        subject.subjectType = type;
+        subject.quotaLimit = limit;
+        subject.periodStart = now;
+        subject.createdAt = now;
+        subject.updatedAt = now;
+        subject.expiresAt = timestampFromInstant(expiresAt);
+        return subject;
+    }
+
+    private boolean isSameUtcDay(Timestamp first, Timestamp second) {
+        if (first == null || second == null) {
+            return false;
+        }
+        LocalDate firstDate = first.toDate().toInstant().atZone(ZoneOffset.UTC).toLocalDate();
+        LocalDate secondDate = second.toDate().toInstant().atZone(ZoneOffset.UTC).toLocalDate();
+        return firstDate.equals(secondDate);
+    }
+
+    private void incrementSubject(QuotaSubject subject, Timestamp now) {
+        subject.usageCount++;
+        subject.updatedAt = now;
+    }
+
+    private QuotaException protectionQuotaException(long accountLimit, PlanType plan, String scope) {
+        return new QuotaException("The free conversion allowance for this device or network has been reached.",
+                Map.of("limit", accountLimit, "remaining", 0, "plan", plan, "scope", scope));
+    }
+
+    private List<DocumentReference> protectionReferences(QuotaReservation reservation) {
+        List<DocumentReference> references = new ArrayList<>();
+        if (reservation.deviceHash != null && !reservation.deviceHash.isBlank()) {
+            references.add(firestore().collection(DEVICE_COLLECTION).document(reservation.deviceHash));
+        }
+        if (reservation.networkHash != null && !reservation.networkHash.isBlank()) {
+            references.add(firestore().collection(NETWORK_COLLECTION).document(reservation.networkHash));
+        }
+        if (reservation.globalCounterId != null && !reservation.globalCounterId.isBlank()) {
+            references.add(firestore().collection(GLOBAL_COLLECTION).document(reservation.globalCounterId));
+        }
+        return references;
+    }
+
+    private void refundProtectionCounters(Transaction transaction,
+            Map<DocumentReference, DocumentSnapshot> snapshots, Timestamp now) {
+        for (Map.Entry<DocumentReference, DocumentSnapshot> entry : snapshots.entrySet()) {
+            QuotaSubject subject = entry.getValue().toObject(QuotaSubject.class);
+            if (subject != null) {
+                transaction.update(entry.getKey(), Map.of(
+                        "usageCount", Math.max(0, subject.usageCount - 1),
+                        "updatedAt", now));
+            }
+        }
     }
 
     public List<UserQuotaWrapper> findAll() {

--- a/src/main/java/com/dime/api/feature/converter/QuotaSubject.java
+++ b/src/main/java/com/dime/api/feature/converter/QuotaSubject.java
@@ -1,0 +1,23 @@
+package com.dime.api.feature.converter;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.annotation.IgnoreExtraProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@IgnoreExtraProperties
+public class QuotaSubject {
+    public String subjectType;
+    public long usageCount;
+    public long quotaLimit;
+    public Timestamp periodStart;
+    public Timestamp expiresAt;
+    public Timestamp createdAt;
+    public Timestamp updatedAt;
+    public List<String> accountHashes = new ArrayList<>();
+}

--- a/src/main/java/com/dime/api/feature/shared/config/FirebaseAuthFilter.java
+++ b/src/main/java/com/dime/api/feature/shared/config/FirebaseAuthFilter.java
@@ -16,6 +16,7 @@ public class FirebaseAuthFilter implements ContainerRequestFilter {
 
     public static final String FIREBASE_UID = "firebase.uid";
     public static final String FIREBASE_EMAIL = "firebase.email";
+    public static final String FIREBASE_EMAIL_VERIFIED = "firebase.emailVerified";
 
     @Inject
     Instance<FirebaseAuth> firebaseAuth;
@@ -37,6 +38,7 @@ public class FirebaseAuthFilter implements ContainerRequestFilter {
             FirebaseToken decodedToken = firebaseAuth.get().verifyIdToken(token);
             requestContext.setProperty(FIREBASE_UID, decodedToken.getUid());
             requestContext.setProperty(FIREBASE_EMAIL, decodedToken.getEmail());
+            requestContext.setProperty(FIREBASE_EMAIL_VERIFIED, decodedToken.isEmailVerified());
             log.debug("Firebase token verified for user: {}", decodedToken.getUid());
         } catch (FirebaseAuthException e) {
             log.warn("Invalid Firebase token: {}", e.getMessage());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -145,6 +145,11 @@ quota.limit.free=${QUOTA_LIMIT_FREE:3}
 quota.limit.pro=${QUOTA_LIMIT_PRO:100}
 quota.limit.business=${QUOTA_LIMIT_BUSINESS:120}
 quota.limit.unlimited=${QUOTA_LIMIT_UNLIMITED:1000000}
+quota.free.device-limit=${QUOTA_FREE_DEVICE_LIMIT:3}
+quota.free.network-daily-limit=${QUOTA_FREE_NETWORK_DAILY_LIMIT:12}
+quota.free.network-account-threshold=${QUOTA_FREE_NETWORK_ACCOUNT_THRESHOLD:3}
+quota.free.global-daily-limit=${QUOTA_FREE_GLOBAL_DAILY_LIMIT:500}
+quota.identity.pepper=${QUOTA_IDENTITY_PEPPER:${AUTH_SESSION_ENCRYPTION_KEY:photocalia-local-only}}
 
 # Application Configuration
 quarkus.application.name=3dime-api
@@ -210,7 +215,7 @@ quarkus.smallrye-health.root-path=/health
 quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=${CORS_ORIGINS:https://3dime.com,https://www.3dime.com,https://photocalia.com,https://www.photocalia.com}
 quarkus.http.cors.methods=GET,PUT,POST,DELETE,PATCH,OPTIONS
-quarkus.http.cors.headers=accept,authorization,content-type,idempotency-key,x-requested-with
+quarkus.http.cors.headers=accept,authorization,content-type,idempotency-key,x-installation-id,x-requested-with
 quarkus.http.cors.exposed-headers=Content-Disposition,Content-Type,X-Request-ID,Deprecation,Sunset
 quarkus.http.cors.access-control-max-age=24H
 %dev.quarkus.http.cors.origins=http://localhost:3000,http://localhost:4200,http://localhost:8080

--- a/src/test/java/com/dime/api/feature/converter/ConverterIntegrationTest.java
+++ b/src/test/java/com/dime/api/feature/converter/ConverterIntegrationTest.java
@@ -49,9 +49,9 @@ public class ConverterIntegrationTest {
             .body(validRequest)
             .when().post("/v1/converter")
             .then()
-                .statusCode(anyOf(is(200), is(422), is(500), is(502), is(503))) // Accept various responses depending on config
+                .statusCode(401)
                 .body("success", notNullValue())
-                .body("timestamp", notNullValue());
+                .body("errorCode", is("AUTHENTICATION_REQUIRED"));
     }
 
     @Test
@@ -74,10 +74,9 @@ public class ConverterIntegrationTest {
             .body(validRequest)
             .when().post("/v1/converter")
             .then()
-                .statusCode(400)
+                .statusCode(401)
                 .body("success", is(false))
-                .body("errorCode", is("VALIDATION_ERROR"))
-                .body("message", containsString("Idempotency-Key"));
+                .body("errorCode", is("AUTHENTICATION_REQUIRED"));
     }
 
     @Test
@@ -99,10 +98,9 @@ public class ConverterIntegrationTest {
             .body(invalidRequest)
             .when().post("/v1/converter")
             .then()
-                .statusCode(400)
+                .statusCode(401)
                 .body("success", is(false))
-                .body("errorCode", is("VALIDATION_ERROR"))
-                .body("message", containsString("empty"));
+                .body("errorCode", is("AUTHENTICATION_REQUIRED"));
     }
 
     @Test
@@ -111,8 +109,8 @@ public class ConverterIntegrationTest {
             .param("userId", "test-user")
             .when().get("/v1/converter/quota-status")
             .then()
-                .statusCode(anyOf(is(200), is(404), is(500))) // User may or may not exist; 500 if Firestore unavailable
-                .body(notNullValue());
+                .statusCode(401)
+                .body("errorCode", is("AUTHENTICATION_REQUIRED"));
     }
 
     @Test 

--- a/src/test/java/com/dime/api/feature/converter/QuotaIdentityServiceTest.java
+++ b/src/test/java/com/dime/api/feature/converter/QuotaIdentityServiceTest.java
@@ -1,0 +1,51 @@
+package com.dime.api.feature.converter;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class QuotaIdentityServiceTest {
+
+    private QuotaIdentityService service;
+    private ContainerRequestContext requestContext;
+
+    @BeforeEach
+    void setup() {
+        service = new QuotaIdentityService();
+        service.pepper = "test-only-secret";
+        requestContext = mock(ContainerRequestContext.class);
+    }
+
+    @Test
+    void sameInstallationSurvivesAccountChangeWithoutStoringRawIdentifiers() {
+        String installationId = "inst_12345678901234567890";
+        when(requestContext.getHeaderString("X-Forwarded-For"))
+                .thenReturn("203.0.113.42, 10.0.0.1");
+
+        QuotaIdentityService.QuotaIdentity first = service.resolve("first-user", installationId, requestContext);
+        QuotaIdentityService.QuotaIdentity second = service.resolve("second-user", installationId, requestContext);
+
+        assertEquals(first.deviceHash(), second.deviceHash());
+        assertEquals(first.networkHash(), second.networkHash());
+        assertNotEquals(first.accountHash(), second.accountHash());
+        assertEquals(64, first.deviceHash().length());
+        assertFalse(first.deviceHash().contains(installationId));
+        assertFalse(first.networkHash().contains("203.0.113.42"));
+    }
+
+    @Test
+    void malformedInstallationFallsBackToAccountScopedLegacyIdentity() {
+        QuotaIdentityService.QuotaIdentity first = service.resolve("first-user", "invalid", requestContext);
+        QuotaIdentityService.QuotaIdentity second = service.resolve("second-user", "invalid", requestContext);
+
+        assertNotEquals(first.deviceHash(), second.deviceHash());
+        assertNull(first.networkHash());
+    }
+}

--- a/src/test/java/com/dime/api/feature/converter/QuotaReservationConcurrencyTest.java
+++ b/src/test/java/com/dime/api/feature/converter/QuotaReservationConcurrencyTest.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -44,6 +46,10 @@ class QuotaReservationConcurrencyTest {
         quotaService.quotaLimitBusiness = 120;
         quotaService.quotaLimitUnlimited = 1_000_000;
         quotaService.reservationTtlMinutes = 15;
+        quotaService.freeDeviceLimit = 3;
+        quotaService.freeNetworkDailyLimit = 12;
+        quotaService.freeNetworkAccountThreshold = 3;
+        quotaService.freeGlobalDailyLimit = 500;
         quotaService.init();
 
         firestore = new InMemoryFirestoreHarness();
@@ -124,21 +130,66 @@ class QuotaReservationConcurrencyTest {
         assertEquals(0, firestore.reservations.size());
     }
 
+    @Test
+    void changingAccountDoesNotResetTheInstallationAllowance() {
+        for (int i = 0; i < 3; i++) {
+            firestore.userQuota = null; // Represents a fresh Firebase account document.
+            quotaService.reserveQuota("account-" + i, null, "switch-" + i, 1,
+                    new QuotaIdentityService.QuotaIdentity("shared-device", null, "account-hash-" + i));
+        }
+
+        firestore.userQuota = null;
+        QuotaException blocked = assertThrows(QuotaException.class,
+                () -> quotaService.reserveQuota("account-4", null, "switch-4", 1,
+                        new QuotaIdentityService.QuotaIdentity("shared-device", null, "account-hash-4")));
+
+        assertEquals("device", ((Map<?, ?>) blocked.getDetails()).get("scope"));
+        assertEquals(3, firestore.subject("quotaDevices", "shared-device").usageCount);
+    }
+
+    @Test
+    void failedConversionRefundsAccountAndProtectionCounters() {
+        QuotaIdentityService.QuotaIdentity identity =
+                new QuotaIdentityService.QuotaIdentity("device-refund", "network-refund", "account-refund");
+
+        quotaService.reserveQuota("refund-user", null, "refund-key", 1, identity);
+        quotaService.failReservation("refund-user", "refund-key", "claude", "provider failure", true);
+
+        assertEquals(0, firestore.userQuota.quotaUsed);
+        assertEquals(0, firestore.subject("quotaDevices", "device-refund").usageCount);
+        assertEquals(0, firestore.subject("quotaNetworks", "network-refund").usageCount);
+        assertEquals(0, firestore.subject("quotaGlobal", LocalDate.now(ZoneOffset.UTC).toString()).usageCount);
+        assertEquals(QuotaReservationState.REFUNDED,
+                firestore.reservations.get("refund-key").getStateType());
+    }
+
     private static class InMemoryFirestoreHarness {
 
         final Firestore firestore = mock(Firestore.class);
         final CollectionReference users = mock(CollectionReference.class);
+        final CollectionReference devices = mock(CollectionReference.class);
+        final CollectionReference networks = mock(CollectionReference.class);
+        final CollectionReference globals = mock(CollectionReference.class);
         final DocumentReference userDoc = mock(DocumentReference.class);
         final CollectionReference reservationCollection = mock(CollectionReference.class);
         final Transaction transaction = mock(Transaction.class);
         final Map<String, QuotaReservation> reservations = new HashMap<>();
         final Map<DocumentReference, String> reservationKeys = new IdentityHashMap<>();
         final Map<String, DocumentReference> reservationRefs = new HashMap<>();
+        final Map<String, DocumentReference> subjectRefs = new HashMap<>();
+        final Map<DocumentReference, QuotaSubject> subjects = new IdentityHashMap<>();
         UserQuota userQuota;
 
         InMemoryFirestoreHarness() {
             when(firestore.collection("users")).thenReturn(users);
+            when(firestore.collection("quotaDevices")).thenReturn(devices);
+            when(firestore.collection("quotaNetworks")).thenReturn(networks);
+            when(firestore.collection("quotaGlobal")).thenReturn(globals);
             when(users.document(any())).thenReturn(userDoc);
+            when(userDoc.get()).thenAnswer(ignored -> ApiFutures.immediateFuture(snapshotFor(userDoc)));
+            mockSubjectCollection(devices, "quotaDevices");
+            mockSubjectCollection(networks, "quotaNetworks");
+            mockSubjectCollection(globals, "quotaGlobal");
             when(userDoc.collection("quotaReservations")).thenReturn(reservationCollection);
             when(reservationCollection.document(any())).thenAnswer(invocation -> {
                 String key = invocation.getArgument(0);
@@ -178,11 +229,32 @@ class QuotaReservationConcurrencyTest {
             }).when(transaction).update(any(DocumentReference.class), any(Map.class));
         }
 
+        private void mockSubjectCollection(CollectionReference collection, String collectionName) {
+            when(collection.document(any())).thenAnswer(invocation -> {
+                String id = invocation.getArgument(0);
+                synchronized (this) {
+                    return subjectRefs.computeIfAbsent(collectionName + ":" + id,
+                            ignored -> mock(DocumentReference.class));
+                }
+            });
+        }
+
+        QuotaSubject subject(String collectionName, String id) {
+            return subjects.get(subjectRefs.get(collectionName + ":" + id));
+        }
+
         private DocumentSnapshot snapshotFor(DocumentReference ref) {
             DocumentSnapshot snapshot = mock(DocumentSnapshot.class);
             if (ref == userDoc) {
                 when(snapshot.exists()).thenReturn(userQuota != null);
                 when(snapshot.toObject(UserQuota.class)).thenReturn(userQuota);
+                return snapshot;
+            }
+
+            QuotaSubject subject = subjects.get(ref);
+            if (subject != null || subjectRefs.containsValue(ref)) {
+                when(snapshot.exists()).thenReturn(subject != null);
+                when(snapshot.toObject(QuotaSubject.class)).thenReturn(subject);
                 return snapshot;
             }
 
@@ -202,6 +274,11 @@ class QuotaReservationConcurrencyTest {
                 return;
             }
 
+            if (value instanceof QuotaSubject subject && subjectRefs.containsValue(ref)) {
+                subjects.put(ref, subject);
+                return;
+            }
+
             String key = reservationKeys.get(ref);
             if (key != null && value instanceof QuotaReservation reservation) {
                 reservations.put(key, reservation);
@@ -215,6 +292,15 @@ class QuotaReservationConcurrencyTest {
 
             if (ref == userDoc && userQuota != null) {
                 applyQuotaUpdates(userQuota, updates);
+                return;
+            }
+
+            QuotaSubject subject = subjects.get(ref);
+            if (subject != null) {
+                Object usageCount = updates.get("usageCount");
+                if (usageCount instanceof Number valueNumber) {
+                    subject.usageCount = valueNumber.longValue();
+                }
                 return;
             }
 


### PR DESCRIPTION
## Summary
- require a verified Firebase account for conversions and quota status
- enforce free allowances by account and pseudonymized browser installation
- add shared-network and daily service-capacity safeguards
- refund every counter when conversion processing fails
- document configuration and update the OpenAPI contract

## Validation
- mvn -B -ntp test (128 tests passing)
- OpenAPI contract regenerated and synchronized